### PR TITLE
docs: establish a Scrum delivery cadence for AI Dev OS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,7 @@ Required rules:
 
 - do not implement without a GitHub Issue
 - follow [`docs/92-development-workflow.md`](../docs/92-development-workflow.md)
+- for multi-step work, follow [`docs/93-scrum-delivery.md`](../docs/93-scrum-delivery.md)
 - prefer config-driven behavior over vendor-specific shell branching
 - update docs and tests with behavior changes
 - run `make test` and `make lint` before considering work complete

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Keep this file short. Put durable detail in normal repository docs and link to t
 Before planning or editing, read:
 
 - [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
+- [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
 - [`docs/40-cli.md`](./docs/40-cli.md)
 - [`docs/41-ai-trust.md`](./docs/41-ai-trust.md)
 - [`tasks/backlog.md`](./tasks/backlog.md)
@@ -70,6 +71,7 @@ If the task changes architecture or long-term operating rules, also read:
 When the task is large, ambiguous, or expected to take multiple meaningful steps, create or update a plan document before major edits.
 
 - Put plans in `PLANS.md` or `docs/adr/` when appropriate.
+- Run the work using the Scrum cadence in [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md).
 - A good plan is self-contained, outcome-focused, and kept up to date as work progresses.
 - If a task is too large for one pass, leave the plan in a restartable state for the next agent.
 
@@ -87,6 +89,7 @@ Before marking work done:
 ## Pointers
 
 - Workflow rules: [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
+- Scrum cadence: [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
 - CLI and config boundaries: [`docs/40-cli.md`](./docs/40-cli.md)
 - Trust defaults: [`docs/41-ai-trust.md`](./docs/41-ai-trust.md)
 - ADR rules: [`docs/adr/README.md`](./docs/adr/README.md)

--- a/PLANS.md
+++ b/PLANS.md
@@ -78,6 +78,15 @@ Specialists can be added per sprint when needed:
 ## Retrospective
 
 - keep
+  - backlog -> issue -> branch の順で切ってから squad を組む流れ
+- change
+  - lightweight process の escape hatch は最初から明文化する
+- stop
+  - ceremony を暗黙知のまま期待する進め方
+
+## Retrospective
+
+- keep
   - tie new operating rules to grep-based structure tests so they do not silently disappear
 - change
   - update `PLANS.md` earlier when the slice changes, so the active issue and squad stay correct without a catch-up edit

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,8 +1,8 @@
 # AI Dev OS Plan
 
 - Date: 2026-03-11
-- Active issue: #42 `docs: make demo sample-project README follow staged AI Dev OS adoption`
-- Branch: `docs/42-demo-readme-staged-adoption`
+- Active issue: #49 `docs: establish a Scrum operating cadence for AI Dev OS delivery`
+- Branch: `docs/49-scrum-delivery-cadence`
 
 ## North Star
 
@@ -13,78 +13,73 @@
 - prefer project-local config and vendor-native capability over shell-wrapper reimplementation
 - keep every newcomer-facing surface aligned on the same failure model and next-step guidance
 
-## MVP
-
-Current newcomer MVP:
-
-- macOS user can run `./install` and `make agent`
-- in an existing repo, `ai init` creates a usable local starter without hand editing shell code
-- `ai doctor` explains missing binaries, prompt/config gaps, and fallback paths before launch
-- `ai workflows` / `ai --help` expose available workflow candidates
-- `ai start` opens a working AI Dev OS workspace for that repo
-- GitHub Actions starter is optional and can be added or skipped at init time
-
 ## Current Goal
 
-Finish the staged-adoption docs pack so the demo fixture, generated starter, quickstart, CLI reference, troubleshooting, and GitHub Actions guidance all tell the same newcomer-first story without losing the deeper daily-tool path.
+Make Scrum-style delivery a durable repo rule instead of an implicit habit, so backlog refinement, sprint commitment, review/demo, and retrospective are all documented and restartable.
 
-## Acceptance Slice
+## Working Agreement
 
-- `demo/sample-project/README.md` explains the local-first staged adoption flow
-- the demo README points to `ai doctor`, `ai workflows`, and `ai start` in order
-- CI/runtime guidance remains secondary and points back to the runtime repo doc split
-- walkthrough and demo tests stay aligned with the new README
+Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md).
 
-## Delivery Shape
+- start from `tasks/backlog.md`, then commit to an issue-backed sprint slice
+- keep `PLANS.md` restartable throughout the sprint
+- do backlog refinement before pulling the next non-trivial item
+- end the sprint with review/demo evidence and a retrospective note
+
+## Sprint Slice
 
 - primary deliverable
-  - a newcomer-first, durable docs narrative for AI Dev OS
+  - a durable Scrum operating guide for AI Dev OS delivery
 - concrete surfaces
-  - root README and quickstart
-  - generated starter README from `ai init`
-  - demo walkthrough and demo fixture README
-  - CLI reference for beginner surface vs deeper surface
-  - GitHub Actions / troubleshooting split for later lanes
-- review contract
-  - `ai doctor` is the first diagnostic step
-  - `ai workflows` / `ai-agent --describe` are discovery and deep-inspection steps
-  - CI, hosted eval, and runtime pinning stay optional later lanes
-  - docs and tests preserve the same failure model across surfaces
+  - [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
+  - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
+  - [`docs/adr/0003-ai-dev-os-scrum-cadence.md`](./docs/adr/0003-ai-dev-os-scrum-cadence.md)
+  - [`tasks/backlog.md`](./tasks/backlog.md)
+  - [`test/repository_structure.sh`](./test/repository_structure.sh)
+- acceptance slice
+  - sprint planning, backlog refinement, review/demo, and retrospective are explicit
+  - recommended squad roles and skill coverage are explicit
+  - current plan references the Scrum guide instead of free-form execution
 
-## PR Shape
+## Squad
 
-- suggested title
-  - `docs: align AI Dev OS around a durable local-first adoption path`
-- issue links
-  - `Closes #42`
-  - `Refs #23`
-  - `Refs #27`
-  - `Refs #29`
-  - `Refs #32`
-- summary bullets
-  - align demo README and walkthrough around `ai doctor` first staged adoption
-  - align generated starter guidance and `ai init` next steps around `ai doctor -> ai workflows -> ai start`
-  - align README, quickstart, CLI, and philosophy around a durable daily-tool north star
-  - keep GitHub Actions, hosted eval, and runtime pinning as later lanes instead of the main path
-  - add order-based regression guards so docs do not drift back into a flat checklist
-- verification bullets
-  - `bash test/ai_init.sh`
-  - `bash test/demo_assets.sh`
-  - `bash test/repository_structure.sh`
-  - `make lint`
-  - `make test`
+- Product / Backlog: Codex
+  - owns issue shape, acceptance criteria, and backlog refinement
+- Delivery / Scrum: Codex
+  - owns sprint commitment, plan hygiene, and ceremony completion
+- Docs / Onboarding: Avicenna
+  - scans newcomer clarity and docs cohesion
+- Review / QA: Mendel
+  - scans regressions, test coverage, and wording drift
 
-## Scout Lanes
+Specialists can be added per sprint when needed:
 
-- Lane A: onboarding/docs scout
-  - keep one agent looking for newcomer friction in generated artifacts, quickstart docs, and troubleshooting flow
-- Lane B: runtime/doctor scout
-  - keep one agent looking for gaps between workflow resolution, fallback behavior, and vendor-native readiness checks
-- Lane C: platform scout
-  - keep one agent looking for Linux/WSL readiness, portability gaps, and late-failing OS wrappers
+- Runtime / Trust specialist
+- Platform / OS specialist
+- Prompt / Eval specialist
 
-## Next Queue
+## Current Sprint Ceremonies
 
-- `docs/demo: sample-project root README を staged adoption と AI Dev OS-first framing に揃える`
-- `refactor: separate runtime-repo docs from adopter-repo troubleshooting more explicitly`
-- `refactor: rename remaining DITFILES-specific internal/help surfaces after user-facing aliases settle`
+- Sprint Planning
+  - commit only issue-backed slices that fit in one focused sprint
+- Backlog Refinement
+  - convert the next likely improvement into a backlog item with a crisp problem and impact
+- Review / Demo
+  - leave proof in tests, diff shape, and PR summary
+- Retrospective
+  - capture what to keep, change, and stop before the next sprint starts
+
+## Verification
+
+- `bash test/repository_structure.sh`
+- `make lint`
+- `make test`
+
+## Retrospective
+
+- keep
+  - tie new operating rules to grep-based structure tests so they do not silently disappear
+- change
+  - update `PLANS.md` earlier when the slice changes, so the active issue and squad stay correct without a catch-up edit
+- stop
+  - treating coordination, refinement, and review as implicit behavior instead of explicit repo rules

--- a/docs/92-development-workflow.md
+++ b/docs/92-development-workflow.md
@@ -34,6 +34,10 @@ agent-specific compatibility file がある場合も、基本方針は `AGENTS.m
 - behavior change がある場合は docs を更新する
 - merge 前に `make test` と `make lint` を通す
 
+大きめの仕事や複数ステップの active work は、free-form に進めず [`docs/93-scrum-delivery.md`](./93-scrum-delivery.md) の cadence に従う。
+つまり backlog refinement, sprint commitment, review/demo, retrospective を repo ルールとして回す。
+一方で single-step の小さな変更まで ceremony を肥大化させる必要はなく、issue-first と test/lint を満たした最小運用でよい。
+
 ## Recommended Labels
 
 - `type:feature`
@@ -59,6 +63,24 @@ agent-specific compatibility file がある場合も、基本方針は `AGENTS.m
 5. 実装、テスト、docs 更新を行う
 6. PR を作って `Closes #<issue>` を付ける
 7. review 後に merge する
+
+## Scrum Cadence For Multi-Step Work
+
+issue-first workflow を守りつつ、multi-step work は軽量な Scrum cadence で回す。
+
+- Sprint Planning
+  - 今回の sprint で close する issue と acceptance slice を決める
+- Backlog Refinement
+  - 次の候補を `tasks/backlog.md` で整え、Problem / Improvement / Impact を粗く揃える
+- Execution
+  - `PLANS.md` を restartable に保ち、必要なら multi-agent lane を明示する
+- Review / Demo
+  - diff, tests, docs 更新で何を達成したかを示す
+- Retrospective
+  - 次に keep / change / stop することを短く残す
+
+詳細な squad roles, Definition of Ready, Definition of Done は [`docs/93-scrum-delivery.md`](./93-scrum-delivery.md) を参照。
+small sprint では 1 人が複数 role を兼務してよい。
 
 ## Branch Naming
 
@@ -111,3 +133,5 @@ bug issue には少なくとも次を書く。
 - 必要なら linked ADR がある
 - tests / lint の結果がある
 - rollout risk が書かれている
+
+Scrum cadence で進めた work では、PR summary から sprint commitment と review/demo evidence が辿れる状態を保つ。

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -1,0 +1,124 @@
+# Scrum Delivery
+
+この repo の active work は issue-first を前提にしつつ、複数ステップにまたがる時は軽量な Scrum cadence で進める。
+AI Dev OS の delivery は ad hoc な issue hopping に戻さず、backlog refinement, sprint planning, review/demo, retrospective を明示的に回す。
+
+## Working Agreement
+
+- multi-step work はこのページの cadence に従う
+- sprint は issue-backed slice で持つ
+- `PLANS.md` は active sprint の restartable source of truth にする
+- sprint 中も backlog refinement を止めず、次の候補を粗く整えておく
+- review/demo と retrospective を省略して次の sprint に飛ばない
+- ただし single-step の小さな変更は、issue-first と verification を満たす最小 ceremony でよい
+
+## Sprint Planning
+
+- 1 sprint で close したい issue を決める
+- acceptance criteria のうち今回達成する slice を明確にする
+- docs, tests, ADR の有無を先に決める
+- parallel lane が必要なら最初に squad を組む
+
+planning の出口は次の状態。
+
+- branch が issue に紐づいている
+- `PLANS.md` が current sprint を説明できる
+- 誰が product, delivery, review を持つか分かる
+- 最小形なら 3 行程度の sprint note でもよい
+
+## Backlog Refinement
+
+- 次の候補を `tasks/backlog.md` で粗く整える
+- Problem, Improvement Idea, Expected Impact が短く説明できる状態にする
+- issue に切る前に scope が 1 sprint で扱えるかを確認する
+- 複数 issue に分けるべきならこの時点で分割する
+
+Definition of Ready:
+
+- problem が 1 段落で説明できる
+- goal / non-goals が分かる
+- acceptance criteria が testable である
+- branch 名の粒度が見えている
+- docs / tests / ADR の必要性が見えている
+
+## Execution
+
+- active issue を主語に進める
+- 実装前に必要な docs と tests の更新箇所を見積もる
+- multi-agent で進める時は write scope を分ける
+- sprint 中の判断は `PLANS.md` と issue に戻せる形にする
+
+## Review / Demo
+
+- diff が sprint goal に対して過不足ないことを示す
+- tests / lint の結果を残す
+- newcomer-facing change なら docs surface の一貫性も確認する
+- demo が必要な change では、実行順や利用者の見え方を説明できる状態にする
+
+## Retrospective
+
+- keep
+  - この sprint で続けるべきやり方
+- change
+  - 次の sprint で変える進め方
+- stop
+  - 速度や品質を落としたやり方
+
+retrospective は長文でなくてよいが、次 sprint の backlog refinement や staffing に効く形で残す。
+最小形なら keep / change / stop を 1 行ずつ残せばよい。
+
+## Squad Roles
+
+- Product / Backlog
+  - issue shape, acceptance criteria, priority, scope split を持つ
+  - 必要 skill: product judgment, docs framing, backlog refinement
+- Delivery / Scrum
+  - sprint commitment, `PLANS.md`, ceremony completion を持つ
+  - 必要 skill: execution control, sequencing, risk management
+- Implementer
+  - main change set を持つ
+  - 必要 skill: shell/code/docs editing, integration judgment
+- Reviewer / QA
+  - regression scan, test coverage, wording drift を持つ
+  - 必要 skill: review discipline, verification, risk spotting
+
+必要に応じて specialist lane を追加してよい。
+
+- Docs / Onboarding specialist
+- Runtime / Trust specialist
+- Platform / OS specialist
+- Prompt / Eval specialist
+
+## Staffing Guidance
+
+1 人または 1 agent が複数 role を兼務してよい。
+最小 squad は 3 lane だが、small sprint では同じ人が Product / Backlog, Delivery / Scrum, Implementer を兼ねてもよい。
+
+- Product / Backlog
+- Delivery / Scrum
+- Reviewer / QA
+
+実装がある sprint では Implementer を明示する。
+複数 lane が並ぶ時は reviewer を最後に置かず、途中から並走させる。
+
+ceremony の最小成果物は次でよい。
+
+- Sprint Planning
+  - issue, branch, acceptance slice を 1 か所に書く
+- Backlog Refinement
+  - 次候補の Problem / Impact を backlog に足す
+- Review / Demo
+  - tests と diff summary を残す
+- Retrospective
+  - keep / change / stop を短く残す
+
+## Definition of Done
+
+- issue exists and the sprint slice matches it
+- docs changed if behavior or operating rules changed
+- tests changed when behavior or durable wording changed
+- `make lint` passes
+- `make test` passes
+- `PLANS.md` is restartable or intentionally closed out
+- review/demo evidence exists
+- retrospective note for the sprint exists in issue, PR, or plan closeout

--- a/docs/adr/0003-ai-dev-os-scrum-cadence.md
+++ b/docs/adr/0003-ai-dev-os-scrum-cadence.md
@@ -1,0 +1,34 @@
+# 0003 AI Dev OS Scrum Cadence
+
+- Status: Accepted
+- Date: 2026-03-11
+
+## Context
+
+AI Dev OS は issue-first, plan-aware な delivery へ寄せてきたが、複数ステップの active work はまだ実質的に ad hoc な運転に寄りやすい。
+
+その結果:
+
+- backlog refinement が後回しになりやすい
+- active sprint と next queue の境界が曖昧になる
+- review/demo と retrospective が暗黙になりやすい
+- multi-agent work の staffing と skill coverage が人依存になる
+
+## Decision
+
+AI Dev OS の multi-step work は lightweight Scrum cadence で進める。
+
+具体的には:
+
+- sprint planning, backlog refinement, review/demo, retrospective を repo-level ceremony として明示する
+- `PLANS.md` を active sprint の restartable artifact として使う
+- `tasks/backlog.md` は refinement 前の inbox 兼 next queue として使う
+- active delivery の詳細ルールは `docs/93-scrum-delivery.md` に置く
+- squad roles と specialist lanes を文書化し、parallel work の staffing を明示する
+
+## Consequences
+
+- active work の進め方が issue-first workflow の上にもう一段そろう
+- 「どこから着手し、どこで振り返るか」が repo ルールとして辿りやすくなる
+- plan, issue, PR, retrospective のつながりを後から追いやすくなる
+- ただし process の重量が増えすぎないよう、small changes まで ceremony を強制しない運用判断は必要になる

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -313,7 +313,7 @@ The demo repo becomes a stronger first-run exemplar of AI Dev OS adoption instea
 ## Task 19
 
 Title: Tighten README granularity around beginner path vs deeper surfaces
-Tracking: #46
+Tracking: #46 (closed)
 
 Problem:
 The top-level `README.md` now tells the right AI Dev OS story, but its granularity is still uneven. The beginner path, host substrate details, optional CI/runtime lanes, and deeper operator surfaces all live in one document at similar visual weight, which makes the README feel denser than the intended newcomer-first entrypoint.
@@ -326,3 +326,20 @@ Refactor `README.md` so the must-know flow stays visible while more detailed CI/
 
 Expected Impact:
 The README becomes easier to scan for newcomers without losing the advanced-path framing or the durable daily-tool positioning.
+
+## Task 20
+
+Title: Establish a Scrum operating cadence for backlog, delivery, and retrospectives
+Tracking: #49
+
+Problem:
+The repo now has a stronger issue-first workflow and clearer product north star, but ongoing work still depends too much on ad hoc execution. There is no durable repo-level agreement for sprint planning, backlog refinement, review, retrospective cadence, or which skill sets should be staffed for multi-step delivery.
+
+Improvement Idea:
+Define a lightweight Scrum-style operating model for AI Dev OS work so active delivery follows a repeatable cadence with clear roles, explicit refinement, and restartable plans.
+
+Implementation Hint:
+Add a durable doc for Scrum cadence and team lanes, link it from development workflow guidance and plans, and spell out how backlog refinement, sprint commitment, review, and retrospective should be run in this repo.
+
+Expected Impact:
+Longer-running work becomes easier to continue, audit, and parallelize without drifting back into unstructured issue hopping.

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -328,12 +328,20 @@ verify_ai_dev_os_docs() {
     || fail "docs/93-scrum-delivery.md does not define Definition of Ready"
   grep -Fq "Definition of Done" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define Definition of Done"
+  grep -Fq "single-step の小さな変更" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not keep the small-change ceremony carve-out"
   grep -Fq "Product / Backlog" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define the Product / Backlog role"
   grep -Fq "Delivery / Scrum" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define the Delivery / Scrum role"
   grep -Fq "Reviewer / QA" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define the Reviewer / QA role"
+  grep -Fq "複数 role を兼務してよい" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not allow one person to hold multiple roles"
+  grep -Fq "review/demo evidence exists" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not keep review/demo evidence in Definition of Done"
+  grep -Fq "retrospective note for the sprint exists" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not keep the retrospective note in Definition of Done"
   grep -Fq "PLANS.md" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not connect Scrum cadence to PLANS.md"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/PLANS.md" \
@@ -348,6 +356,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/adr/0002-ai-dev-os-primary-surface.md does not record the AI Dev OS product-surface decision"
   grep -Fq "lightweight Scrum cadence" "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md" \
     || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not record the Scrum cadence decision"
+  grep -Fq "small changes" "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md" \
+    || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not keep the small-change escape hatch"
   grep -Fq "do not implement without a GitHub Issue" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not enforce issue-first work"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/AGENTS.md" \

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -218,9 +218,11 @@ verify_layout_scaffold() {
   assert_executable "$REPO/context/build-context.sh"
   assert_file "$REPO/tasks/backlog.md"
   assert_file "$REPO/docs/92-development-workflow.md"
+  assert_file "$REPO/docs/93-scrum-delivery.md"
   assert_file "$REPO/docs/adr/README.md"
   assert_file "$REPO/docs/adr/0001-ai-dev-os-delivery-workflow.md"
   assert_file "$REPO/docs/adr/0002-ai-dev-os-primary-surface.md"
+  assert_file "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md"
   assert_file "$REPO/docs/05-demo-walkthrough.md"
   assert_file "$REPO/docs/41-ai-trust.md"
   assert_file "$REPO/docs/42-github-actions.md"
@@ -310,6 +312,32 @@ verify_ai_dev_os_docs() {
     || fail "docs/42-github-actions.md does not cover fixed-ref stability guidance"
   grep -Fq "AGENTS.md" "$REPO/docs/92-development-workflow.md" \
     || fail "docs/92-development-workflow.md does not mention AGENTS.md"
+  grep -Fq "backlog refinement" "$REPO/docs/92-development-workflow.md" \
+    || fail "docs/92-development-workflow.md does not mention backlog refinement"
+  grep -Fq "retrospective" "$REPO/docs/92-development-workflow.md" \
+    || fail "docs/92-development-workflow.md does not mention retrospective"
+  grep -Fq "Sprint Planning" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not have a Sprint Planning section"
+  grep -Fq "Backlog Refinement" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not have a Backlog Refinement section"
+  grep -Fq "Review / Demo" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not have a Review / Demo section"
+  grep -Fq "Retrospective" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not have a Retrospective section"
+  grep -Fq "Definition of Ready" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define Definition of Ready"
+  grep -Fq "Definition of Done" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define Definition of Done"
+  grep -Fq "Product / Backlog" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the Product / Backlog role"
+  grep -Fq "Delivery / Scrum" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the Delivery / Scrum role"
+  grep -Fq "Reviewer / QA" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the Reviewer / QA role"
+  grep -Fq "PLANS.md" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not connect Scrum cadence to PLANS.md"
+  grep -Fq "docs/93-scrum-delivery.md" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not point to docs/93-scrum-delivery.md"
   grep -Fq "AI Dev OS" "$REPO/docs/90-philosophy.md" \
     || fail "docs/90-philosophy.md does not use the AI Dev OS framing"
   grep -Fq "AI Dev OS control plane" "$REPO/docs/91-state-ownership.md" \
@@ -318,8 +346,14 @@ verify_ai_dev_os_docs() {
     || fail "docs/61-local-customization.md does not recommend AI Dev OS editor aliases"
   grep -Fq "primary product surface" "$REPO/docs/adr/0002-ai-dev-os-primary-surface.md" \
     || fail "docs/adr/0002-ai-dev-os-primary-surface.md does not record the AI Dev OS product-surface decision"
+  grep -Fq "lightweight Scrum cadence" "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md" \
+    || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not record the Scrum cadence decision"
   grep -Fq "do not implement without a GitHub Issue" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not enforce issue-first work"
+  grep -Fq "docs/93-scrum-delivery.md" "$REPO/AGENTS.md" \
+    || fail "AGENTS.md does not point to docs/93-scrum-delivery.md"
+  grep -Fq "docs/93-scrum-delivery.md" "$REPO/.github/copilot-instructions.md" \
+    || fail ".github/copilot-instructions.md does not point to docs/93-scrum-delivery.md"
   grep -Fq "docs/05-demo-walkthrough.md" "$REPO/README.md" \
     || fail "README.md does not link to the demo walkthrough"
 }


### PR DESCRIPTION
## Summary
- document a lightweight Scrum cadence for multi-step AI Dev OS work
- link the new cadence from workflow, agent, ADR, backlog, and plan surfaces
- add regression guards so backlog refinement, review/demo, retrospective, and role coverage stay explicit

## Testing
- bash test/repository_structure.sh
- make lint
- make test

## Retrospective
- keep: issue-first branching and parallel review lanes
- change: document lightweight escape hatches early
- stop: assuming ceremonies are obvious without writing them down

Closes #49