### PR TITLE
docs: add retrospective memory feedback loop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ Required rules:
 - do not implement without a GitHub Issue
 - follow [`docs/92-development-workflow.md`](../docs/92-development-workflow.md)
 - for multi-step work, follow [`docs/93-scrum-delivery.md`](../docs/93-scrum-delivery.md)
+- for multi-agent or handoff-heavy work, leave compressed memory under [`tasks/sprint-memory/`](../tasks/sprint-memory/)
 - prefer config-driven behavior over vendor-specific shell branching
 - update docs and tests with behavior changes
 - run `make test` and `make lint` before considering work complete

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ansible/local.yml
 
 # AI Dev OS generated context
 .context/
+
+# Optional raw coordination logs for sprint memory compression
+tasks/sprint-memory/raw/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Before planning or editing, read:
 - [`docs/41-ai-trust.md`](./docs/41-ai-trust.md)
 - [`tasks/backlog.md`](./tasks/backlog.md)
 
+If you are resuming or handing off multi-step work, also read the latest relevant artifact under [`tasks/sprint-memory/`](./tasks/sprint-memory/).
+
 If the task changes architecture or long-term operating rules, also read:
 
 - [`docs/adr/README.md`](./docs/adr/README.md)
@@ -72,6 +74,7 @@ When the task is large, ambiguous, or expected to take multiple meaningful steps
 
 - Put plans in `PLANS.md` or `docs/adr/` when appropriate.
 - Run the work using the Scrum cadence in [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md).
+- For multi-agent or handoff-heavy work, leave a compressed memory artifact under [`tasks/sprint-memory/`](./tasks/sprint-memory/).
 - A good plan is self-contained, outcome-focused, and kept up to date as work progresses.
 - If a task is too large for one pass, leave the plan in a restartable state for the next agent.
 
@@ -90,6 +93,7 @@ Before marking work done:
 
 - Workflow rules: [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
 - Scrum cadence: [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
+- Sprint memory: [`tasks/sprint-memory/`](./tasks/sprint-memory/)
 - CLI and config boundaries: [`docs/40-cli.md`](./docs/40-cli.md)
 - Trust defaults: [`docs/41-ai-trust.md`](./docs/41-ai-trust.md)
 - ADR rules: [`docs/adr/README.md`](./docs/adr/README.md)

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,8 +1,9 @@
 # AI Dev OS Plan
 
 - Date: 2026-03-11
-- Active issue: #49 `docs: establish a Scrum operating cadence for AI Dev OS delivery`
-- Branch: `docs/49-scrum-delivery-cadence`
+- Active issue: #53 `docs: make retrospectives update the system and preserve agent memory`
+- Branch: `docs/53-retro-memory-loop`
+- Memory Artifact: [`tasks/sprint-memory/issue-53.md`](./tasks/sprint-memory/issue-53.md)
 
 ## North Star
 
@@ -15,7 +16,7 @@
 
 ## Current Goal
 
-Make Scrum-style delivery a durable repo rule instead of an implicit habit, so backlog refinement, sprint commitment, review/demo, and retrospective are all documented and restartable.
+Make retrospectives improve the operating system instead of ending as dead-end notes, and preserve compressed sprint memory so multi-agent work can survive context loss and handoff.
 
 ## Working Agreement
 
@@ -23,23 +24,26 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 
 - start from `tasks/backlog.md`, then commit to an issue-backed sprint slice
 - keep `PLANS.md` restartable throughout the sprint
-- do backlog refinement before pulling the next non-trivial item
-- end the sprint with review/demo evidence and a retrospective note
+- keep compressed handoff context in [`tasks/sprint-memory/`](./tasks/sprint-memory/)
+- end the sprint with review/demo evidence, retrospective output, and explicit system updates
 
 ## Sprint Slice
 
 - primary deliverable
-  - a durable Scrum operating guide for AI Dev OS delivery
+  - a durable retrospective feedback loop and sprint-memory contract
 - concrete surfaces
   - [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
   - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
-  - [`docs/adr/0003-ai-dev-os-scrum-cadence.md`](./docs/adr/0003-ai-dev-os-scrum-cadence.md)
+  - [`AGENTS.md`](./AGENTS.md)
+  - [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)
+  - [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
+  - [`tasks/sprint-memory/issue-53.md`](./tasks/sprint-memory/issue-53.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - sprint planning, backlog refinement, review/demo, and retrospective are explicit
-  - recommended squad roles and skill coverage are explicit
-  - current plan references the Scrum guide instead of free-form execution
+  - retrospectives map to backlog / plans / docs / tests / instructions / ADR or explicit no-op
+  - the repo defines a standard compressed sprint memory location and format
+  - active planning surfaces point to sprint memory artifacts
 
 ## Squad
 
@@ -47,27 +51,21 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
   - owns issue shape, acceptance criteria, and backlog refinement
 - Delivery / Scrum: Codex
   - owns sprint commitment, plan hygiene, and ceremony completion
-- Docs / Onboarding: Avicenna
-  - scans newcomer clarity and docs cohesion
-- Review / QA: Mendel
-  - scans regressions, test coverage, and wording drift
-
-Specialists can be added per sprint when needed:
-
-- Runtime / Trust specialist
-- Platform / OS specialist
-- Prompt / Eval specialist
+- Explorer / Design: Gibbs
+  - scans memory artifact shape and handoff clarity
+- Explorer / Guardrails: Hypatia
+  - scans regression guards and wording drift
 
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - commit only issue-backed slices that fit in one focused sprint
+  - issue `#53`, branch `docs/53-retro-memory-loop`, and memory artifact path are fixed
 - Backlog Refinement
-  - convert the next likely improvement into a backlog item with a crisp problem and impact
+  - Task 21 was added and converted into issue `#53`
 - Review / Demo
-  - leave proof in tests, diff shape, and PR summary
+  - leave proof in docs, tests, and the sprint-memory artifact
 - Retrospective
-  - capture what to keep, change, and stop before the next sprint starts
+  - capture keep / change / stop and which system surfaces were updated
 
 ## Verification
 
@@ -78,17 +76,8 @@ Specialists can be added per sprint when needed:
 ## Retrospective
 
 - keep
-  - backlog -> issue -> branch の順で切ってから squad を組む流れ
+  - using the current sprint itself as the first real memory-artifact trial
 - change
-  - lightweight process の escape hatch は最初から明文化する
+  - standardize one artifact path before more branches invent alternatives
 - stop
-  - ceremony を暗黙知のまま期待する進め方
-
-## Retrospective
-
-- keep
-  - tie new operating rules to grep-based structure tests so they do not silently disappear
-- change
-  - update `PLANS.md` earlier when the slice changes, so the active issue and squad stay correct without a catch-up edit
-- stop
-  - treating coordination, refinement, and review as implicit behavior instead of explicit repo rules
+  - leaving handoff context only in ephemeral agent state

--- a/docs/92-development-workflow.md
+++ b/docs/92-development-workflow.md
@@ -37,6 +37,7 @@ agent-specific compatibility file がある場合も、基本方針は `AGENTS.m
 大きめの仕事や複数ステップの active work は、free-form に進めず [`docs/93-scrum-delivery.md`](./93-scrum-delivery.md) の cadence に従う。
 つまり backlog refinement, sprint commitment, review/demo, retrospective を repo ルールとして回す。
 一方で single-step の小さな変更まで ceremony を肥大化させる必要はなく、issue-first と test/lint を満たした最小運用でよい。
+retrospective の出力は note で終わらせず、必要なら backlog, plans, docs, tests, instructions, ADR へ反映し、圧縮した handoff は `tasks/sprint-memory/issue-<id>.md` に残す。
 
 ## Recommended Labels
 
@@ -77,10 +78,11 @@ issue-first workflow を守りつつ、multi-step work は軽量な Scrum cadenc
 - Review / Demo
   - diff, tests, docs 更新で何を達成したかを示す
 - Retrospective
-  - 次に keep / change / stop することを短く残す
+  - 次に keep / change / stop することを短く残し、必要なら backlog / docs / tests / agent instructions / ADR に反映する
 
 詳細な squad roles, Definition of Ready, Definition of Done は [`docs/93-scrum-delivery.md`](./93-scrum-delivery.md) を参照。
 small sprint では 1 人が複数 role を兼務してよい。
+context loss や handoff が起こる work では、compressed sprint memory artifact を `tasks/sprint-memory/issue-<id>.md` に残す。
 
 ## Branch Naming
 

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -11,6 +11,7 @@ AI Dev OS の delivery は ad hoc な issue hopping に戻さず、backlog refin
 - sprint 中も backlog refinement を止めず、次の候補を粗く整えておく
 - review/demo と retrospective を省略して次の sprint に飛ばない
 - ただし single-step の小さな変更は、issue-first と verification を満たす最小 ceremony でよい
+- retrospective は dead-end note にせず、次の system update と sprint memory まで残す
 
 ## Sprint Planning
 
@@ -47,6 +48,7 @@ Definition of Ready:
 - 実装前に必要な docs と tests の更新箇所を見積もる
 - multi-agent で進める時は write scope を分ける
 - sprint 中の判断は `PLANS.md` と issue に戻せる形にする
+- context loss や handoff に備えて、lane ごとの要点は `tasks/sprint-memory/` に圧縮して残せる形で集める
 
 ## Review / Demo
 
@@ -54,6 +56,7 @@ Definition of Ready:
 - tests / lint の結果を残す
 - newcomer-facing change なら docs surface の一貫性も確認する
 - demo が必要な change では、実行順や利用者の見え方を説明できる状態にする
+- multi-agent sprint では、review/demo までに compressed memory に decisions, lane outcomes, rerun commands を揃える
 
 ## Retrospective
 
@@ -66,6 +69,27 @@ Definition of Ready:
 
 retrospective は長文でなくてよいが、次 sprint の backlog refinement や staffing に効く形で残す。
 最小形なら keep / change / stop を 1 行ずつ残せばよい。
+
+## Retrospective Feedback Loop
+
+retrospective の出口は「感想」ではなく、どこを更新するかが決まっている状態にする。
+
+- backlog
+  - 次 sprint で切る改善候補を `tasks/backlog.md` に足す
+- plans
+  - `PLANS.md` の squad, risk, memory artifact, resume point を更新する
+- docs
+  - operating docs や newcomer docs を更新する
+- tests
+  - durable wording や operating rule を test で固定する
+- instructions
+  - `AGENTS.md` や compatibility instructions を更新する
+- ADR
+  - 長期運用判断として記録が必要かを判断する
+- no-op
+  - 変えるものがなければ、それも retrospective の結果として残す
+
+少なくとも 1 つは「どこに反映したか」を示すか、明示的に no-op を残す。
 
 ## Squad Roles
 
@@ -110,7 +134,41 @@ ceremony の最小成果物は次でよい。
 - Review / Demo
   - tests と diff summary を残す
 - Retrospective
-  - keep / change / stop を短く残す
+  - keep / change / stop を短く残し、反映先か no-op を書く
+
+## Sprint Memory
+
+compressed sprint memory artifact は `tasks/sprint-memory/` に置く。
+`PLANS.md` は live な active-work doc とし、長く残す handoff / memory compression は別 artifact に逃がす。
+
+標準は compressed memory で、full raw chat transcript は標準 artifact にしない。
+raw coordination log は次の時だけ optional で残す。
+
+- 意思決定の根拠が要約だけでは落ちる
+- 複数 lane の非同期判断を監査したい
+- 外部 review 向けに coordination evidence が必要
+
+標準ファイル名:
+
+- compressed memory
+  - `tasks/sprint-memory/issue-<id>.md`
+- optional raw coordination log
+  - `tasks/sprint-memory/raw/issue-<id>.md`
+
+memory artifact の最小項目:
+
+- Sprint
+  - issue, branch, date, lanes
+- Compressed Memory
+  - goal, decisions, constraints, current state, next likely moves, open questions
+- Lane Notes
+  - Product / Delivery / Review などの短い要約
+- Retrospective Output
+  - keep, change, stop, follow-ups
+- System Updates
+  - backlog / plans / docs / tests / instructions / ADR が `updated / not needed / follow-up issue` のどれか
+- Handoff
+  - next agent が最初に読むもの、rerun commands、known risks
 
 ## Definition of Done
 
@@ -122,3 +180,5 @@ ceremony の最小成果物は次でよい。
 - `PLANS.md` is restartable or intentionally closed out
 - review/demo evidence exists
 - retrospective note for the sprint exists in issue, PR, or plan closeout
+- retrospective output is mapped to backlog, plans, docs, tests, instructions, ADR, or explicit no-op
+- multi-agent or handoff-heavy work leaves `tasks/sprint-memory/issue-<id>.md` or explicitly records why one was not needed

--- a/docs/adr/0004-ai-dev-os-retro-memory-loop.md
+++ b/docs/adr/0004-ai-dev-os-retro-memory-loop.md
@@ -1,0 +1,33 @@
+# 0004 AI Dev OS Retrospective Feedback And Sprint Memory
+
+- Status: Accepted
+- Date: 2026-03-11
+
+## Context
+
+AI Dev OS now has a Scrum cadence, but retrospective output can still die as a note instead of improving the operating system.
+At the same time, multi-agent work is exposed to context loss, handoff gaps, and memory compression artifacts that may vanish once a session ends.
+
+The repo needs a durable rule for:
+
+- turning retrospective output into concrete system updates
+- preserving compressed handoff context without defaulting to full raw chat transcript storage
+
+## Decision
+
+AI Dev OS will treat retrospective output as a system-update trigger and store compressed sprint memory artifacts under `tasks/sprint-memory/`.
+
+Specifically:
+
+- retrospectives must map to backlog, plans, docs, tests, instructions, ADR, or explicit no-op
+- `PLANS.md` remains the live active-work document
+- compressed sprint memory becomes the durable handoff artifact
+- raw coordination logs are optional and only kept when compressed memory is insufficient
+- the directory and wording are guarded in repository structure tests
+
+## Consequences
+
+- multi-agent work becomes easier to resume after context loss or handoff
+- operating rules can improve sprint by sprint instead of relying on tribal memory
+- the repo avoids making full transcript retention the default
+- contributors need to maintain one more durable artifact for longer-running work

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -343,3 +343,20 @@ Add a durable doc for Scrum cadence and team lanes, link it from development wor
 
 Expected Impact:
 Longer-running work becomes easier to continue, audit, and parallelize without drifting back into unstructured issue hopping.
+
+## Task 21
+
+Title: Make retrospectives update the operating system and preserve compressed agent memory
+Tracking: #53
+
+Problem:
+The repo now has Scrum cadence, but retrospectives can still become dead-end notes. There is no durable rule for turning retrospective output into backlog, plans, guardrails, or agent-readable memory artifacts, and no standard place to preserve compressed coordination context when model memory is reset.
+
+Improvement Idea:
+Define a feedback loop where each sprint retrospective can produce concrete follow-ups for docs, backlog, tests, or instructions, and store a compact agent memory artifact that captures the key decisions, lane outcomes, and handoff context.
+
+Implementation Hint:
+Extend the Scrum docs and plan guidance with a retrospective-to-system update loop, define a durable location and format for compressed sprint memory, and add tests that keep the loop from disappearing.
+
+Expected Impact:
+The operating model improves itself over time, and multi-agent work becomes easier to resume after context loss or handoff.

--- a/tasks/sprint-memory/README.md
+++ b/tasks/sprint-memory/README.md
@@ -1,0 +1,81 @@
+# Sprint Memory
+
+このディレクトリは multi-step work や multi-agent work の compressed memory artifact を置く。
+`PLANS.md` は live な active-work doc とし、ここは handoff と context-loss 耐性のための圧縮記録を残す場所にする。
+
+## When To Write One
+
+- 複数 agent が並走した
+- handoff が入る
+- context loss が起きやすい長めの作業だった
+- retrospective の結果を次 sprint に確実につなぎたい
+
+single-step の小さな変更では不要なこともある。
+
+## File Naming
+
+- compressed memory
+  - `issue-<id>.md`
+- optional raw coordination log
+  - `raw/issue-<id>.md`
+
+raw log は標準 artifact にしない。
+標準は compressed memory で、必要な時だけ raw coordination log を optional で残す。
+
+## Raw Log vs Compressed Memory
+
+- compressed memory
+  - 次の agent が再開するための正本
+  - goal, decisions, constraints, current state, next likely moves を短く残す
+- raw coordination log
+  - 判断差分の監査や failure analysis が必要な時だけ残す
+  - full chat transcript を常時保存する運用にはしない
+
+## Minimal Format
+
+## Sprint
+
+- issue
+- branch
+- date
+- lanes
+
+## Compressed Memory
+
+- goal
+- decisions
+- constraints
+- current state
+- next likely moves
+- open questions
+
+## Lane Notes
+
+- Product / Backlog
+- Delivery / Scrum
+- Implementer
+- Reviewer / QA
+
+## Retrospective Output
+
+- keep
+- change
+- stop
+- follow-ups
+
+## System Updates
+
+- backlog
+- plans
+- docs
+- tests
+- instructions
+- ADR
+
+各項目は `updated / not needed / follow-up issue` のどれかで残す。
+
+## Handoff
+
+- next agent が最初に読むもの
+- rerun commands
+- known risks

--- a/tasks/sprint-memory/TEMPLATE.md
+++ b/tasks/sprint-memory/TEMPLATE.md
@@ -1,0 +1,48 @@
+# Sprint
+
+- issue: `#<id>`
+- branch: `<type>/<id>-short-name`
+- date: `YYYY-MM-DD`
+- lanes:
+  - Product / Backlog:
+  - Delivery / Scrum:
+  - Implementer:
+  - Reviewer / QA:
+
+## Compressed Memory
+
+- goal:
+- decisions:
+- constraints:
+- current state:
+- next likely moves:
+- open questions:
+
+## Lane Notes
+
+- Product / Backlog:
+- Delivery / Scrum:
+- Implementer:
+- Reviewer / QA:
+
+## Retrospective Output
+
+- keep
+- change
+- stop
+- follow-ups
+
+## System Updates
+
+- backlog:
+- plans:
+- docs:
+- tests:
+- instructions:
+- ADR:
+
+## Handoff
+
+- read first:
+- rerun commands:
+- known risks:

--- a/tasks/sprint-memory/issue-53.md
+++ b/tasks/sprint-memory/issue-53.md
@@ -1,0 +1,76 @@
+# Sprint
+
+- issue: `#53`
+- branch: `docs/53-retro-memory-loop`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Explorer / Design: Gibbs
+  - Explorer / Guardrails: Hypatia
+
+## Compressed Memory
+
+- goal:
+  - make retrospectives update the operating system and preserve compressed agent memory
+- decisions:
+  - use `tasks/sprint-memory/` as the durable location for compressed sprint memory
+  - keep `PLANS.md` as the live active-work document, not the long-term handoff store
+  - default to compressed summaries, with raw coordination logs optional under `tasks/sprint-memory/raw/`
+- constraints:
+  - keep the process lightweight for small changes
+  - do not make full chat transcript retention the default
+  - preserve issue-first and test-guarded workflow rules
+- current state:
+  - issue exists
+  - Scrum docs are being updated to add retrospective feedback loops and memory artifact rules
+  - active plan is aligned to issue `#53` and points to this artifact
+- next likely moves:
+  - finish normalizing wording and tests around `tasks/sprint-memory/`
+  - verify guard coverage with `make lint` and `make test`
+- open questions:
+  - whether to keep a sample artifact permanently or rely only on the README contract
+
+## Lane Notes
+
+- Product / Backlog
+  - converted the idea into Task 21 and issue `#53`
+- Delivery / Scrum
+  - using the new Scrum cadence to drive the follow-up itself
+- Explorer / Design
+  - recommended separating live planning from durable compressed memory
+- Explorer / Guardrails
+  - still pending at the time this artifact was first written
+
+## Retrospective Output
+
+- keep
+  - tie new operating rules to grep-based tests so they do not disappear
+- change
+  - standardize memory artifact placement before more branches invent new paths
+- stop
+  - relying on free-form plan notes as the only handoff surface
+- follow-ups
+  - consider whether PR templates should eventually link sprint memory artifacts directly
+
+## System Updates
+
+- backlog: `updated`
+- plans: `updated`
+- docs: `updated`
+- tests: `updated`
+- instructions: `updated`
+- ADR: `updated`
+
+## Handoff
+
+- read first:
+  - `docs/93-scrum-delivery.md`
+  - `PLANS.md`
+  - `test/repository_structure.sh`
+- rerun commands:
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - wording and tests must stay on `tasks/sprint-memory/` only; mixed paths would break the handoff contract

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -217,12 +217,15 @@ verify_layout_scaffold() {
   assert_file "$REPO/context/build-context.sh"
   assert_executable "$REPO/context/build-context.sh"
   assert_file "$REPO/tasks/backlog.md"
+  assert_dir "$REPO/tasks/sprint-memory"
+  assert_file "$REPO/tasks/sprint-memory/README.md"
   assert_file "$REPO/docs/92-development-workflow.md"
   assert_file "$REPO/docs/93-scrum-delivery.md"
   assert_file "$REPO/docs/adr/README.md"
   assert_file "$REPO/docs/adr/0001-ai-dev-os-delivery-workflow.md"
   assert_file "$REPO/docs/adr/0002-ai-dev-os-primary-surface.md"
   assert_file "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md"
+  assert_file "$REPO/docs/adr/0004-ai-dev-os-retro-memory-loop.md"
   assert_file "$REPO/docs/05-demo-walkthrough.md"
   assert_file "$REPO/docs/41-ai-trust.md"
   assert_file "$REPO/docs/42-github-actions.md"
@@ -316,6 +319,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/92-development-workflow.md does not mention backlog refinement"
   grep -Fq "retrospective" "$REPO/docs/92-development-workflow.md" \
     || fail "docs/92-development-workflow.md does not mention retrospective"
+  grep -Fq "tasks/sprint-memory/" "$REPO/docs/92-development-workflow.md" \
+    || fail "docs/92-development-workflow.md does not mention compressed sprint memory"
   grep -Fq "Sprint Planning" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not have a Sprint Planning section"
   grep -Fq "Backlog Refinement" "$REPO/docs/93-scrum-delivery.md" \
@@ -324,6 +329,10 @@ verify_ai_dev_os_docs() {
     || fail "docs/93-scrum-delivery.md does not have a Review / Demo section"
   grep -Fq "Retrospective" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not have a Retrospective section"
+  grep -Fq "Retrospective Feedback Loop" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the retrospective feedback loop"
+  grep -Fq "Sprint Memory" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define sprint memory"
   grep -Fq "Definition of Ready" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define Definition of Ready"
   grep -Fq "Definition of Done" "$REPO/docs/93-scrum-delivery.md" \
@@ -342,10 +351,22 @@ verify_ai_dev_os_docs() {
     || fail "docs/93-scrum-delivery.md does not keep review/demo evidence in Definition of Done"
   grep -Fq "retrospective note for the sprint exists" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not keep the retrospective note in Definition of Done"
+  grep -Fq "backlog, plans, docs, tests, instructions, ADR, or explicit no-op" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not map retrospective output to system updates"
+  grep -Fq "tasks/sprint-memory/issue-<id>.md" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the compressed memory artifact location"
+  grep -Fq "tasks/sprint-memory/raw/issue-<id>.md" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the optional raw log location"
+  grep -Fq "System Updates" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define system updates"
   grep -Fq "PLANS.md" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not connect Scrum cadence to PLANS.md"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/PLANS.md" \
     || fail "PLANS.md does not point to docs/93-scrum-delivery.md"
+  grep -Fq "Memory Artifact" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not define a memory artifact field"
+  grep -Fq "tasks/sprint-memory/" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not point to tasks/sprint-memory/"
   grep -Fq "AI Dev OS" "$REPO/docs/90-philosophy.md" \
     || fail "docs/90-philosophy.md does not use the AI Dev OS framing"
   grep -Fq "AI Dev OS control plane" "$REPO/docs/91-state-ownership.md" \
@@ -358,12 +379,22 @@ verify_ai_dev_os_docs() {
     || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not record the Scrum cadence decision"
   grep -Fq "small changes" "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md" \
     || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not keep the small-change escape hatch"
+  grep -Fq "compressed sprint memory" "$REPO/docs/adr/0004-ai-dev-os-retro-memory-loop.md" \
+    || fail "docs/adr/0004-ai-dev-os-retro-memory-loop.md does not record the compressed sprint memory decision"
+  grep -Fq "Compressed Memory" "$REPO/tasks/sprint-memory/README.md" \
+    || fail "tasks/sprint-memory/README.md does not define compressed memory"
+  grep -Fq "System Updates" "$REPO/tasks/sprint-memory/README.md" \
+    || fail "tasks/sprint-memory/README.md does not define system updates"
   grep -Fq "do not implement without a GitHub Issue" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not enforce issue-first work"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/AGENTS.md" \
     || fail "AGENTS.md does not point to docs/93-scrum-delivery.md"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not point to docs/93-scrum-delivery.md"
+  grep -Fq "tasks/sprint-memory/" "$REPO/AGENTS.md" \
+    || fail "AGENTS.md does not point to tasks/sprint-memory/"
+  grep -Fq "tasks/sprint-memory/" "$REPO/.github/copilot-instructions.md" \
+    || fail ".github/copilot-instructions.md does not point to tasks/sprint-memory/"
   grep -Fq "docs/05-demo-walkthrough.md" "$REPO/README.md" \
     || fail "README.md does not link to the demo walkthrough"
 }


### PR DESCRIPTION
## Summary
- make retrospectives feed backlog, plans, docs, tests, instructions, ADR, or explicit no-op
- define `tasks/sprint-memory/` as the standard location for compressed sprint memory artifacts
- add guards and a current-sprint artifact so handoff survives context loss

## Testing
- bash test/repository_structure.sh
- make lint
- make test

## Retrospective
- keep: encode operating rules in docs plus grep-based tests
- change: standardize the memory artifact path before more variants appear
- stop: leaving multi-agent context only in ephemeral session state

Closes #53