### PR TITLE
docs: capture sprint memory in PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,25 @@
 
 - what changed
 - why this change exists
+- keep this terse for small changes
 
 ## Related
 
 - Closes #
 - ADR:
+
+## Sprint Context
+
+- Sprint Memory: `tasks/sprint-memory/issue-<id>.md` or `n/a (small change)`
+- Review / Demo: `n/a (small change)` is acceptable when there is nothing to demo beyond the diff and checks
+- System Updates:
+  - use `updated / not needed / follow-up issue`
+  - backlog:
+  - plans:
+  - docs:
+  - tests:
+  - instructions:
+  - ADR:
 
 ## Checks
 

--- a/docs/92-development-workflow.md
+++ b/docs/92-development-workflow.md
@@ -136,4 +136,5 @@ bug issue には少なくとも次を書く。
 - tests / lint の結果がある
 - rollout risk が書かれている
 
-Scrum cadence で進めた work では、PR summary から sprint commitment と review/demo evidence が辿れる状態を保つ。
+Scrum cadence で進めた work では、PR summary から sprint memory, review/demo evidence, retrospective-driven system updates が辿れる状態を保つ。
+`.github/pull_request_template.md` の `Sprint Context` はその最小入力面で、small change なら `n/a` で済ませてよい。

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -57,6 +57,7 @@ Definition of Ready:
 - newcomer-facing change なら docs surface の一貫性も確認する
 - demo が必要な change では、実行順や利用者の見え方を説明できる状態にする
 - multi-agent sprint では、review/demo までに compressed memory に decisions, lane outcomes, rerun commands を揃える
+- PR では `.github/pull_request_template.md` の `Sprint Context` に sprint memory, review/demo, system updates を短く残す
 
 ## Retrospective
 

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -395,6 +395,14 @@ verify_ai_dev_os_docs() {
     || fail "AGENTS.md does not point to tasks/sprint-memory/"
   grep -Fq "tasks/sprint-memory/" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not point to tasks/sprint-memory/"
+  grep -Fq "Sprint Memory" "$REPO/.github/pull_request_template.md" \
+    || fail ".github/pull_request_template.md does not prompt for sprint memory"
+  grep -Fq "Review / Demo" "$REPO/.github/pull_request_template.md" \
+    || fail ".github/pull_request_template.md does not prompt for review/demo evidence"
+  grep -Fq "System Updates" "$REPO/.github/pull_request_template.md" \
+    || fail ".github/pull_request_template.md does not prompt for system updates"
+  grep -Fq "n/a (small change)" "$REPO/.github/pull_request_template.md" \
+    || fail ".github/pull_request_template.md does not preserve the small-change escape hatch"
   grep -Fq "docs/05-demo-walkthrough.md" "$REPO/README.md" \
     || fail "README.md does not link to the demo walkthrough"
 }


### PR DESCRIPTION
## Summary
- teach the PR template to capture sprint memory, review/demo evidence, and system updates
- keep a small-change escape hatch with `n/a (small change)`
- add guards so the template stays aligned with the Scrum and sprint-memory rules

## Testing
- bash test/repository_structure.sh
- make lint
- make test

Closes #57