### PR TITLE
docs: align issue templates with sprint shape

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -44,6 +44,25 @@ body:
       label: Logs / Evidence
       description: Command output, screenshots, or file references.
   - type: textarea
+    id: fix_surfaces
+    attributes:
+      label: Likely Fix Surfaces
+      description: Which surfaces likely need changes or explicit no-op?
+      placeholder: |
+        - code
+        - docs
+        - tests
+        - instructions: not needed
+  - type: textarea
+    id: sprint_shape
+    attributes:
+      label: Sprint Shape / Scope
+      description: Optional hint for likely lanes, handoffs, or whether this is a small fix.
+      placeholder: |
+        - Implementer
+        - Reviewer / QA
+        - small change: yes/no
+  - type: textarea
     id: fix_hint
     attributes:
       label: Suspected Cause / Fix Hint

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -46,6 +46,26 @@ body:
     validations:
       required: true
   - type: textarea
+    id: system_updates
+    attributes:
+      label: Likely System Updates
+      description: Which surfaces will likely change or need explicit no-op?
+      placeholder: |
+        - docs
+        - tests
+        - instructions
+        - ADR: not needed
+  - type: textarea
+    id: sprint_shape
+    attributes:
+      label: Sprint Shape / Lanes
+      description: Optional hint for likely lanes, handoffs, or whether this is a small change.
+      placeholder: |
+        - Product / Backlog
+        - Implementer
+        - Reviewer / QA
+        - small change: yes/no
+  - type: textarea
     id: links
     attributes:
       label: Notes / Links

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -377,3 +377,20 @@ Extend `.github/pull_request_template.md` with `Sprint Memory`, `Review / Demo`,
 
 Expected Impact:
 The repo's delivery template reflects the operating model instead of relying on contributors to remember the new rules from memory.
+
+## Task 23
+
+Title: Teach issue templates to capture likely system updates and sprint shape
+Tracking: pending
+
+Problem:
+The repo now has stronger Scrum and sprint-memory rules, but issue creation still stops at problem, goal, proposal, and acceptance criteria. That makes likely docs/tests/instructions/ADR impact and sprint shape too easy to defer until implementation starts.
+
+Improvement Idea:
+Extend issue templates so contributors can capture likely system-update surfaces and sprint shape while defining the work, without turning issue creation into heavy ceremony.
+
+Implementation Hint:
+Add a small section to the feature and bug issue templates for expected docs/tests/instructions/ADR impact and optional sprint lane notes, then add narrow structure guards so the prompts stay aligned with the current operating model.
+
+Expected Impact:
+Issue creation better matches the repo's delivery model, and later planning or handoff has fewer hidden assumptions.

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -387,6 +387,14 @@ verify_ai_dev_os_docs() {
     || fail "tasks/sprint-memory/README.md does not define system updates"
   grep -Fq "do not implement without a GitHub Issue" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not enforce issue-first work"
+  grep -Fq "Likely System Updates" "$REPO/.github/ISSUE_TEMPLATE/feature.yml" \
+    || fail ".github/ISSUE_TEMPLATE/feature.yml does not prompt for likely system updates"
+  grep -Fq "Sprint Shape / Lanes" "$REPO/.github/ISSUE_TEMPLATE/feature.yml" \
+    || fail ".github/ISSUE_TEMPLATE/feature.yml does not prompt for sprint shape"
+  grep -Fq "Likely Fix Surfaces" "$REPO/.github/ISSUE_TEMPLATE/bug.yml" \
+    || fail ".github/ISSUE_TEMPLATE/bug.yml does not prompt for likely fix surfaces"
+  grep -Fq "Sprint Shape / Scope" "$REPO/.github/ISSUE_TEMPLATE/bug.yml" \
+    || fail ".github/ISSUE_TEMPLATE/bug.yml does not prompt for sprint scope"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/AGENTS.md" \
     || fail "AGENTS.md does not point to docs/93-scrum-delivery.md"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/.github/copilot-instructions.md" \


### PR DESCRIPTION
## Summary
- add lightweight sprint-shape and system-update prompts to the issue templates
- keep the issue creation flow small while making likely docs/tests/instructions/ADR impact visible earlier
- add guards so the prompts stay aligned with the current Scrum workflow

## Testing
- bash test/repository_structure.sh
- make lint
- make test

Closes #61