### PR TITLE
docs: default turns to sprint slices

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ Required rules:
 - do not implement without a GitHub Issue
 - follow [`docs/92-development-workflow.md`](../docs/92-development-workflow.md)
 - for multi-step work, follow [`docs/93-scrum-delivery.md`](../docs/93-scrum-delivery.md)
+- default to one user/assistant round-trip as one sprint unless the issue explicitly spans multiple turns
 - for multi-agent or handoff-heavy work, leave compressed memory under [`tasks/sprint-memory/`](../tasks/sprint-memory/)
 - prefer config-driven behavior over vendor-specific shell branching
 - update docs and tests with behavior changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ If the task changes architecture or long-term operating rules, also read:
 When the task is large, ambiguous, or expected to take multiple meaningful steps, create or update a plan document before major edits.
 
 - Put plans in `PLANS.md` or `docs/adr/` when appropriate.
+- Default to treating one user/assistant round-trip as one sprint unless the issue explicitly spans multiple turns.
 - Run the work using the Scrum cadence in [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md).
 - For multi-agent or handoff-heavy work, leave a compressed memory artifact under [`tasks/sprint-memory/`](./tasks/sprint-memory/).
 - A good plan is self-contained, outcome-focused, and kept up to date as work progresses.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,9 +1,9 @@
 # AI Dev OS Plan
 
 - Date: 2026-03-11
-- Active issue: #53 `docs: make retrospectives update the system and preserve agent memory`
-- Branch: `docs/53-retro-memory-loop`
-- Memory Artifact: [`tasks/sprint-memory/issue-53.md`](./tasks/sprint-memory/issue-53.md)
+- Active issue: #65 `docs: default each user turn to one sprint with agent-run Scrum`
+- Branch: `docs/65-turn-scoped-sprint-rule`
+- Memory Artifact: `not needed in this turn-scoped sprint; fallback location is tasks/sprint-memory/`
 
 ## North Star
 
@@ -16,56 +16,50 @@
 
 ## Current Goal
 
-Make retrospectives improve the operating system instead of ending as dead-end notes, and preserve compressed sprint memory so multi-agent work can survive context loss and handoff.
+Make the collaboration cadence explicit: one user/assistant round-trip defaults to one sprint, and agents are responsible for running planning, execution, review/demo, and retrospective inside that turn unless the issue intentionally spans multiple turns.
 
 ## Working Agreement
 
 Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md).
 
 - start from `tasks/backlog.md`, then commit to an issue-backed sprint slice
-- keep `PLANS.md` restartable throughout the sprint
-- keep compressed handoff context in [`tasks/sprint-memory/`](./tasks/sprint-memory/)
-- end the sprint with review/demo evidence, retrospective output, and explicit system updates
+- default to 1 user turn = 1 sprint
+- only span multiple turns when the issue explicitly justifies it
+- end the turn with review/demo evidence and a retrospective outcome
 
 ## Sprint Slice
 
 - primary deliverable
-  - a durable retrospective feedback loop and sprint-memory contract
+  - a durable turn-scoped sprint rule for this collaboration style
 - concrete surfaces
   - [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
   - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
   - [`AGENTS.md`](./AGENTS.md)
   - [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)
-  - [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
-  - [`tasks/sprint-memory/issue-53.md`](./tasks/sprint-memory/issue-53.md)
+  - [`docs/adr/0005-turn-scoped-sprint-cadence.md`](./docs/adr/0005-turn-scoped-sprint-cadence.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - retrospectives map to backlog / plans / docs / tests / instructions / ADR or explicit no-op
-  - the repo defines a standard compressed sprint memory location and format
-  - active planning surfaces point to sprint memory artifacts
+  - turn-scoped sprint default is explicit
+  - exceptions for intentional multi-turn work are explicit
+  - agent-facing instructions reflect the rule
 
 ## Squad
 
 - Product / Backlog: Codex
-  - owns issue shape, acceptance criteria, and backlog refinement
 - Delivery / Scrum: Codex
-  - owns sprint commitment, plan hygiene, and ceremony completion
-- Explorer / Design: Gibbs
-  - scans memory artifact shape and handoff clarity
-- Explorer / Guardrails: Hypatia
-  - scans regression guards and wording drift
+- Reviewer / QA: Codex
 
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#53`, branch `docs/53-retro-memory-loop`, and memory artifact path are fixed
+  - issue `#65` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 21 was added and converted into issue `#53`
+  - Task 24 was added and converted into issue `#65`
 - Review / Demo
-  - leave proof in docs, tests, and the sprint-memory artifact
+  - leave proof in docs and structure tests
 - Retrospective
-  - capture keep / change / stop and which system surfaces were updated
+  - keep the turn-scoped rule lightweight and exception-driven
 
 ## Verification
 
@@ -76,8 +70,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - using the current sprint itself as the first real memory-artifact trial
+  - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - standardize one artifact path before more branches invent alternatives
+  - make the turn boundary explicit earlier so cadence expectations are visible
 - stop
-  - leaving handoff context only in ephemeral agent state
+  - relying on implicit conversation rhythm as the only sprint definition

--- a/docs/92-development-workflow.md
+++ b/docs/92-development-workflow.md
@@ -68,6 +68,7 @@ retrospective の出力は note で終わらせず、必要なら backlog, plans
 ## Scrum Cadence For Multi-Step Work
 
 issue-first workflow を守りつつ、multi-step work は軽量な Scrum cadence で回す。
+この collaboration では default として 1 user turn を 1 sprint slice とみなす。
 
 - Sprint Planning
   - 今回の sprint で close する issue と acceptance slice を決める

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -13,6 +13,15 @@ AI Dev OS の delivery は ad hoc な issue hopping に戻さず、backlog refin
 - ただし single-step の小さな変更は、issue-first と verification を満たす最小 ceremony でよい
 - retrospective は dead-end note にせず、次の system update と sprint memory まで残す
 
+この collaboration mode では、default として「ユーザーとの 1 往復 = 1 sprint」とみなす。
+つまり 1 turn の中で planning, execution, review/demo, retrospective まで agents が回す。
+
+例外:
+
+- issue の slice が 1 turn で完了しないと明確に分かっている
+- 外部待ち、長時間検証、段階的 rollout で intentionally turn をまたぐ
+- small change なので full sprint ではなく最小 ceremony で済む
+
 ## Sprint Planning
 
 - 1 sprint で close したい issue を決める
@@ -26,6 +35,7 @@ planning の出口は次の状態。
 - `PLANS.md` が current sprint を説明できる
 - 誰が product, delivery, review を持つか分かる
 - 最小形なら 3 行程度の sprint note でもよい
+- current turn が 1 sprint か、intentional multi-turn sprint かが明記されている
 
 ## Backlog Refinement
 
@@ -183,3 +193,4 @@ memory artifact の最小項目:
 - retrospective note for the sprint exists in issue, PR, or plan closeout
 - retrospective output is mapped to backlog, plans, docs, tests, instructions, ADR, or explicit no-op
 - multi-agent or handoff-heavy work leaves `tasks/sprint-memory/issue-<id>.md` or explicitly records why one was not needed
+- default turn-scoped sprint なら、その user turn の中で sprint closeout まで終える

--- a/docs/adr/0005-turn-scoped-sprint-cadence.md
+++ b/docs/adr/0005-turn-scoped-sprint-cadence.md
@@ -1,0 +1,27 @@
+# 0005 Turn-Scoped Sprint Cadence
+
+- Status: Accepted
+- Date: 2026-03-11
+
+## Context
+
+AI Dev OS now has Scrum delivery rules and sprint-memory artifacts, but the practical cadence of this collaboration can still be interpreted loosely.
+Without an explicit default, a user turn might behave like an arbitrary fragment of a sprint instead of a complete sprint slice with planning, execution, review/demo, and retrospective.
+
+## Decision
+
+For this collaboration mode, default to treating one user/assistant round-trip as one sprint.
+
+Specifically:
+
+- each turn should normally include sprint planning, execution, review/demo, and retrospective
+- agents are responsible for running that cadence inside the turn
+- an issue may intentionally span multiple turns only when the work explicitly justifies it
+- small changes may still use the minimal-ceremony escape hatch already defined by the Scrum docs
+
+## Consequences
+
+- collaboration cadence becomes predictable to both user and agents
+- sprint closeout is expected at the end of each turn by default
+- multi-turn work needs to say why it remains open instead of drifting implicitly
+- agents must be more deliberate about sprint boundaries and closeout evidence

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -394,3 +394,20 @@ Add a small section to the feature and bug issue templates for expected docs/tes
 
 Expected Impact:
 Issue creation better matches the repo's delivery model, and later planning or handoff has fewer hidden assumptions.
+
+## Task 24
+
+Title: Default each user turn to one sprint with agent-run Scrum inside it
+Tracking: #65
+
+Problem:
+The repo now has Scrum rules, but the cadence is still repo-level and can be interpreted loosely. For this collaboration style, there is still no durable rule that one user/assistant turn should default to one sprint, with planning, execution, review/demo, and retrospective handled by agents inside that turn.
+
+Improvement Idea:
+Define a turn-scoped Scrum rule where each user round-trip is normally treated as one sprint slice, unless an issue explicitly spans multiple turns.
+
+Implementation Hint:
+Extend the Scrum delivery doc, agent instructions, and ADR set so turn-scoped sprint behavior is explicit, lightweight exceptions are documented, and tests keep the wording from drifting.
+
+Expected Impact:
+Collaboration becomes more predictable: each turn has a clear sprint boundary, agents know when to plan and retro, and users get a visible cadence without extra coordination overhead.

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -226,6 +226,7 @@ verify_layout_scaffold() {
   assert_file "$REPO/docs/adr/0002-ai-dev-os-primary-surface.md"
   assert_file "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md"
   assert_file "$REPO/docs/adr/0004-ai-dev-os-retro-memory-loop.md"
+  assert_file "$REPO/docs/adr/0005-turn-scoped-sprint-cadence.md"
   assert_file "$REPO/docs/05-demo-walkthrough.md"
   assert_file "$REPO/docs/41-ai-trust.md"
   assert_file "$REPO/docs/42-github-actions.md"
@@ -323,6 +324,10 @@ verify_ai_dev_os_docs() {
     || fail "docs/92-development-workflow.md does not mention compressed sprint memory"
   grep -Fq "Sprint Planning" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not have a Sprint Planning section"
+  grep -Fq "1 往復 = 1 sprint" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the turn-scoped sprint default"
+  grep -Fq "intentionally turn をまたぐ" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the multi-turn exception"
   grep -Fq "Backlog Refinement" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not have a Backlog Refinement section"
   grep -Fq "Review / Demo" "$REPO/docs/93-scrum-delivery.md" \
@@ -381,6 +386,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/adr/0003-ai-dev-os-scrum-cadence.md does not keep the small-change escape hatch"
   grep -Fq "compressed sprint memory" "$REPO/docs/adr/0004-ai-dev-os-retro-memory-loop.md" \
     || fail "docs/adr/0004-ai-dev-os-retro-memory-loop.md does not record the compressed sprint memory decision"
+  grep -Fq "one user/assistant round-trip as one sprint" "$REPO/docs/adr/0005-turn-scoped-sprint-cadence.md" \
+    || fail "docs/adr/0005-turn-scoped-sprint-cadence.md does not record the turn-scoped sprint decision"
   grep -Fq "Compressed Memory" "$REPO/tasks/sprint-memory/README.md" \
     || fail "tasks/sprint-memory/README.md does not define compressed memory"
   grep -Fq "System Updates" "$REPO/tasks/sprint-memory/README.md" \
@@ -401,8 +408,12 @@ verify_ai_dev_os_docs() {
     || fail ".github/copilot-instructions.md does not point to docs/93-scrum-delivery.md"
   grep -Fq "tasks/sprint-memory/" "$REPO/AGENTS.md" \
     || fail "AGENTS.md does not point to tasks/sprint-memory/"
+  grep -Fq "one user/assistant round-trip as one sprint" "$REPO/AGENTS.md" \
+    || fail "AGENTS.md does not define the turn-scoped sprint default"
   grep -Fq "tasks/sprint-memory/" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not point to tasks/sprint-memory/"
+  grep -Fq "one user/assistant round-trip as one sprint" "$REPO/.github/copilot-instructions.md" \
+    || fail ".github/copilot-instructions.md does not define the turn-scoped sprint default"
   grep -Fq "Sprint Memory" "$REPO/.github/pull_request_template.md" \
     || fail ".github/pull_request_template.md does not prompt for sprint memory"
   grep -Fq "Review / Demo" "$REPO/.github/pull_request_template.md" \


### PR DESCRIPTION
## Summary
- default one user/assistant round-trip to one sprint slice in the Scrum docs
- document when an issue may intentionally span multiple turns
- align agent instructions, plans, ADR, and guards with the turn-scoped sprint rule

## Testing
- bash test/repository_structure.sh
- make lint
- make test

Closes #65