### PR TITLE
chore: sync turn-sprint backlog tracking

### DIFF
--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -398,7 +398,7 @@ Issue creation better matches the repo's delivery model, and later planning or h
 ## Task 24
 
 Title: Default each user turn to one sprint with agent-run Scrum inside it
-Tracking: #65
+Tracking: #65 (closed)
 
 Problem:
 The repo now has Scrum rules, but the cadence is still repo-level and can be interpreted loosely. For this collaboration style, there is still no durable rule that one user/assistant turn should default to one sprint, with planning, execution, review/demo, and retrospective handled by agents inside that turn.


### PR DESCRIPTION
## Summary
- mark Task 24 as `#65 (closed)` in the backlog
- keep backlog history aligned with the merged turn-scoped sprint rule

## Testing
- bash test/repository_structure.sh
- git diff --check

Closes #67