### PR TITLE
docs: define a PLANS.md closeout contract for turn-scoped sprints

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,9 +1,12 @@
 # AI Dev OS Plan
 
 - Date: 2026-03-11
-- Active issue: #65 `docs: default each user turn to one sprint with agent-run Scrum`
-- Branch: `docs/65-turn-scoped-sprint-rule`
-- Memory Artifact: `not needed in this turn-scoped sprint; fallback location is tasks/sprint-memory/`
+- Sprint Status: `closed`
+- Sprint Scope: `turn-scoped`
+- Active issue: #69 `docs: define a PLANS.md closeout contract for turn-scoped sprints`
+- Branch: `docs/69-plans-closeout-contract`
+- Memory Artifact: `tasks/sprint-memory/issue-69.md`
+- Resume Point: closeout completed for this turn-scoped sprint; next work should start from a new issue-backed sprint
 
 ## North Star
 
@@ -16,7 +19,7 @@
 
 ## Current Goal
 
-Make the collaboration cadence explicit: one user/assistant round-trip defaults to one sprint, and agents are responsible for running planning, execution, review/demo, and retrospective inside that turn unless the issue intentionally spans multiple turns.
+Define a minimal closeout contract for `PLANS.md` so turn-scoped sprints do not leave stale active-plan metadata behind after merge.
 
 ## Working Agreement
 
@@ -30,36 +33,37 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
 - primary deliverable
-  - a durable turn-scoped sprint rule for this collaboration style
+  - a durable `PLANS.md` closeout contract for turn-scoped sprints
 - concrete surfaces
-  - [`docs/92-development-workflow.md`](./docs/92-development-workflow.md)
   - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
-  - [`AGENTS.md`](./AGENTS.md)
-  - [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)
-  - [`docs/adr/0005-turn-scoped-sprint-cadence.md`](./docs/adr/0005-turn-scoped-sprint-cadence.md)
+  - [`PLANS.md`](./PLANS.md)
+  - [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - turn-scoped sprint default is explicit
-  - exceptions for intentional multi-turn work are explicit
-  - agent-facing instructions reflect the rule
+  - `docs/93-scrum-delivery.md` defines what `active`, `multi-turn`, and `closed` mean for `PLANS.md`
+  - `PLANS.md` shows the closeout shape for a completed sprint
+  - sprint-memory guidance explains when `PLANS.md` should point to a memory artifact versus `not needed`
 
 ## Squad
 
 - Product / Backlog: Codex
 - Delivery / Scrum: Codex
+- Implementer: Codex
 - Reviewer / QA: Codex
+- Docs / Onboarding specialist: Avicenna
+- Reviewer / QA specialist: Mendel
 
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#65` is the sprint slice for this turn
+  - issue `#69` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 24 was added and converted into issue `#65`
+  - Task 25 was added and converted into issue `#69`
 - Review / Demo
-  - leave proof in docs and structure tests
+  - show the new closeout fields, memory handoff wording, and guard coverage
 - Retrospective
-  - keep the turn-scoped rule lightweight and exception-driven
+  - keep the closeout contract short enough to avoid heavy archival overhead
 
 ## Verification
 
@@ -67,11 +71,30 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 - `make lint`
 - `make test`
 
+## Closeout
+
+- Review / Demo
+  - define a canonical `PLANS.md` closeout contract in [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
+  - align [`PLANS.md`](./PLANS.md) to the new `Sprint Status` / `Sprint Scope` / `Memory Artifact` / `Resume Point` shape
+  - clarify memory handoff wording in [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
+  - lock the contract with [`test/repository_structure.sh`](./test/repository_structure.sh)
+- Retrospective
+  - keep: the turn-scoped sprint rule lightweight and grep-guarded
+  - change: make plan closeout explicit instead of inferring it from merge state
+  - stop: leaving `PLANS.md` in an active-looking state after the sprint is done
+- System Updates
+  - backlog: updated
+  - plans: updated
+  - docs: updated
+  - tests: updated
+  - instructions: not needed
+  - ADR: not needed
+
 ## Retrospective
 
 - keep
   - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - make the turn boundary explicit earlier so cadence expectations are visible
+  - define closeout fields explicitly instead of relying on implied plan state
 - stop
-  - relying on implicit conversation rhythm as the only sprint definition
+  - leaving merged work behind with a plan that still reads as active

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -36,6 +36,7 @@ planning の出口は次の状態。
 - 誰が product, delivery, review を持つか分かる
 - 最小形なら 3 行程度の sprint note でもよい
 - current turn が 1 sprint か、intentional multi-turn sprint かが明記されている
+- `PLANS.md` の `Sprint Status` が `active`, `multi-turn`, `closed` のどれかで分かる
 
 ## Backlog Refinement
 
@@ -147,6 +148,37 @@ ceremony の最小成果物は次でよい。
 - Retrospective
   - keep / change / stop を短く残し、反映先か no-op を書く
 
+## PLANS Closeout Contract
+
+`PLANS.md` は active sprint の live doc だが、turn-scoped sprint では merge 後に stale な active state を残さない。
+最低限、次の field を持つ。
+
+- `Sprint Status`
+  - `active`
+    - この turn で進行中の sprint
+  - `multi-turn`
+    - issue が intentionally 次 turn へ続く sprint
+  - `closed`
+    - この turn の sprint が closeout まで終わった状態
+- `Sprint Scope`
+  - `turn-scoped` か `multi-turn`
+- `Memory Artifact`
+  - `tasks/sprint-memory/issue-<id>.md`
+  - または `not needed in this sprint`
+- `Resume Point`
+  - `active` と `multi-turn` では次に何を再開するか
+  - `closed` では closeout 済みであることを短く示す
+
+`Sprint Status: closed` の時は、`PLANS.md` に少なくとも次を残す。
+
+- `## Closeout`
+  - `Review / Demo`
+  - `Retrospective`
+  - `System Updates`
+
+turn-scoped sprint では default として、この closeout shape までその user turn の中で埋める。
+intentionally multi-turn にする時だけ、`Sprint Status: multi-turn` と `Resume Point` を残して次 turn に渡す。
+
 ## Sprint Memory
 
 compressed sprint memory artifact は `tasks/sprint-memory/` に置く。
@@ -158,6 +190,15 @@ raw coordination log は次の時だけ optional で残す。
 - 意思決定の根拠が要約だけでは落ちる
 - 複数 lane の非同期判断を監査したい
 - 外部 review 向けに coordination evidence が必要
+
+`PLANS.md` から sprint memory への handoff は explicit にする。
+
+- multi-agent または handoff-heavy work
+  - `Memory Artifact: tasks/sprint-memory/issue-<id>.md`
+- small sprint で artifact が不要
+  - `Memory Artifact: not needed in this sprint`
+
+どちらでも `Memory Artifact` を空欄にしない。
 
 標準ファイル名:
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -411,3 +411,20 @@ Extend the Scrum delivery doc, agent instructions, and ADR set so turn-scoped sp
 
 Expected Impact:
 Collaboration becomes more predictable: each turn has a clear sprint boundary, agents know when to plan and retro, and users get a visible cadence without extra coordination overhead.
+
+## Task 25
+
+Title: Define a PLANS.md closeout contract for turn-scoped sprints
+Tracking: #69 (closed)
+
+Problem:
+The repo now treats one user turn as one sprint by default, but `PLANS.md` still relies on convention to indicate whether a sprint is active, intentionally spanning multiple turns, or fully closed out. That makes stale active-plan state too easy to leave behind after merge.
+
+Improvement Idea:
+Define a small, durable closeout contract for `PLANS.md` so turn-scoped sprints clearly record whether they are active, intentionally multi-turn, or closed, and how they hand off to `tasks/sprint-memory/` when needed.
+
+Implementation Hint:
+Update the Scrum delivery doc, `PLANS.md`, and sprint-memory guidance with a canonical closeout shape, then lock the wording down with narrow structure tests.
+
+Expected Impact:
+The repo keeps a restartable plan surface during active work without leaving misleading active sprint metadata behind after work lands.

--- a/tasks/sprint-memory/README.md
+++ b/tasks/sprint-memory/README.md
@@ -12,6 +12,15 @@
 
 single-step の小さな変更では不要なこともある。
 
+`PLANS.md` 側では `Memory Artifact` を必ず明示する。
+
+- artifact を残す
+  - `Memory Artifact: tasks/sprint-memory/issue-<id>.md`
+- artifact が不要
+  - `Memory Artifact: not needed in this sprint`
+
+空欄のまま closeout しない。
+
 ## File Naming
 
 - compressed memory

--- a/tasks/sprint-memory/issue-69.md
+++ b/tasks/sprint-memory/issue-69.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#69`
+- branch: `docs/69-plans-closeout-contract`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex + Mendel
+  - Docs / Onboarding specialist: Avicenna
+
+## Compressed Memory
+
+- goal: define a minimal `PLANS.md` closeout contract so turn-scoped sprints do not leave stale active-plan metadata behind
+- decisions:
+  - keep the contract docs-first and grep-guarded
+  - use canonical `Sprint Status`, `Sprint Scope`, `Memory Artifact`, and `Resume Point` fields in `PLANS.md`
+  - require `## Closeout` for closed turn-scoped sprints
+  - make memory handoff explicit as either a concrete artifact path or `not needed in this sprint`
+- constraints:
+  - stay within one turn-scoped sprint
+  - avoid adding automation that rewrites `PLANS.md`
+  - avoid a new ADR unless the current cadence docs are insufficient
+- current state: docs, plan surface, sprint-memory guidance, and structure tests are aligned on the closeout contract
+- next likely moves: start the next sprint from a new issue-backed branch; do not reopen this plan
+- open questions: whether a future sprint should add a reusable `PLANS.md` template generator or leave the contract docs-only
+
+## Lane Notes
+
+- Product / Backlog: converted the next operating-model gap into Task 25 and issue `#69`
+- Delivery / Scrum: kept this sprint to one docs-and-guards slice and closed it in-turn
+- Implementer: updated `docs/93-scrum-delivery.md`, `PLANS.md`, `tasks/sprint-memory/README.md`, and `test/repository_structure.sh`
+- Reviewer / QA: used specialist feedback to keep the contract small and testable, centered on stale-plan prevention
+
+## Retrospective Output
+
+- keep
+  - converting collaboration habits into repo artifacts and guards
+- change
+  - define plan closeout state directly instead of relying on implied merge completion
+- stop
+  - treating `PLANS.md` as implicitly current after a sprint has already ended
+- follow-ups
+  - consider whether future plan ergonomics need a dedicated reusable template or helper
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `docs/93-scrum-delivery.md`
+  - `PLANS.md`
+  - `tasks/sprint-memory/README.md`
+- rerun commands:
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - grep-based guards depend on stable canonical labels, so future wording edits should preserve those labels

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -366,12 +366,28 @@ verify_ai_dev_os_docs() {
     || fail "docs/93-scrum-delivery.md does not define system updates"
   grep -Fq "PLANS.md" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not connect Scrum cadence to PLANS.md"
+  grep -Fq "PLANS Closeout Contract" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the PLANS closeout contract"
+  grep -Fq "Sprint Status" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define sprint status in PLANS.md"
+  grep -Fq "## Closeout" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the PLANS closeout section"
+  grep -Fq "not needed in this sprint" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not define the no-artifact closeout wording"
   grep -Fq "docs/93-scrum-delivery.md" "$REPO/PLANS.md" \
     || fail "PLANS.md does not point to docs/93-scrum-delivery.md"
+  grep -Fq "Sprint Status" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not define a sprint status field"
+  grep -Fq "Sprint Scope" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not define a sprint scope field"
   grep -Fq "Memory Artifact" "$REPO/PLANS.md" \
     || fail "PLANS.md does not define a memory artifact field"
+  grep -Fq "Resume Point" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not define a resume point field"
   grep -Fq "tasks/sprint-memory/" "$REPO/PLANS.md" \
     || fail "PLANS.md does not point to tasks/sprint-memory/"
+  grep -Fq "## Closeout" "$REPO/PLANS.md" \
+    || fail "PLANS.md does not define a closeout section"
   grep -Fq "AI Dev OS" "$REPO/docs/90-philosophy.md" \
     || fail "docs/90-philosophy.md does not use the AI Dev OS framing"
   grep -Fq "AI Dev OS control plane" "$REPO/docs/91-state-ownership.md" \
@@ -392,6 +408,10 @@ verify_ai_dev_os_docs() {
     || fail "tasks/sprint-memory/README.md does not define compressed memory"
   grep -Fq "System Updates" "$REPO/tasks/sprint-memory/README.md" \
     || fail "tasks/sprint-memory/README.md does not define system updates"
+  grep -Fq "Memory Artifact: tasks/sprint-memory/issue-<id>.md" "$REPO/tasks/sprint-memory/README.md" \
+    || fail "tasks/sprint-memory/README.md does not define the canonical memory artifact handoff"
+  grep -Fq "Memory Artifact: not needed in this sprint" "$REPO/tasks/sprint-memory/README.md" \
+    || fail "tasks/sprint-memory/README.md does not define the no-artifact handoff wording"
   grep -Fq "do not implement without a GitHub Issue" "$REPO/.github/copilot-instructions.md" \
     || fail ".github/copilot-instructions.md does not enforce issue-first work"
   grep -Fq "Likely System Updates" "$REPO/.github/ISSUE_TEMPLATE/feature.yml" \


### PR DESCRIPTION
## Summary
- define a canonical `PLANS.md` closeout contract for turn-scoped sprints
- make sprint-memory handoff explicit as either an artifact path or `not needed in this sprint`
- lock the contract down with structure tests and a concrete sprint-memory example

## Related
- Closes #69
- ADR: n/a

## Sprint Context
- Sprint Memory: `tasks/sprint-memory/issue-69.md`
- Review / Demo: `PLANS.md` now shows `Sprint Status`, `Sprint Scope`, `Memory Artifact`, `Resume Point`, and `## Closeout`; `docs/93-scrum-delivery.md` defines the contract and `tasks/sprint-memory/README.md` defines the handoff wording
- System Updates:
  - backlog: updated
  - plans: updated
  - docs: updated
  - tests: updated
  - instructions: not needed
  - ADR: not needed

## Checks
- [x] `make test`
- [x] `make lint`
- [x] docs updated if behavior changed
- [x] linked issue has clear acceptance criteria

## Notes
- rollout concerns: low; this is docs-and-guardrails only
- follow-up work: consider whether future plan ergonomics need a reusable helper or template generator