### PR TITLE
docs: add a reusable PLANS.md template for turn-scoped and multi-turn sprints

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #69 `docs: define a PLANS.md closeout contract for turn-scoped sprints`
-- Branch: `docs/69-plans-closeout-contract`
-- Memory Artifact: `tasks/sprint-memory/issue-69.md`
-- Resume Point: closeout completed for this turn-scoped sprint; next work should start from a new issue-backed sprint
+- Active issue: #71 `docs: add a reusable PLANS.md template for turn-scoped and multi-turn sprints`
+- Branch: `docs/71-plans-template`
+- Memory Artifact: `tasks/sprint-memory/issue-71.md`
+- Resume Point: reusable plan template landed; start the next sprint from a new issue-backed branch and refresh `PLANS.md` from the template
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Define a minimal closeout contract for `PLANS.md` so turn-scoped sprints do not leave stale active-plan metadata behind after merge.
+Add a reusable `PLANS.md` template so turn-scoped and intentionally multi-turn sprints start from the canonical shape instead of ad hoc copying.
 
 ## Working Agreement
 
@@ -33,17 +33,18 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
 - primary deliverable
-  - a durable `PLANS.md` closeout contract for turn-scoped sprints
+  - a reusable `PLANS.md` template for turn-scoped and multi-turn sprints
 - concrete surfaces
+  - [`templates/plans/PLANS.md`](./templates/plans/PLANS.md)
   - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - `docs/93-scrum-delivery.md` defines what `active`, `multi-turn`, and `closed` mean for `PLANS.md`
-  - `PLANS.md` shows the closeout shape for a completed sprint
-  - sprint-memory guidance explains when `PLANS.md` should point to a memory artifact versus `not needed`
+  - a reusable plan template exists in the repo
+  - the template covers `turn-scoped` and `multi-turn` use
+  - `docs/93-scrum-delivery.md` points to the template as the recommended starting shape
+  - structure tests guard the template and its canonical fields
 
 ## Squad
 
@@ -57,13 +58,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#69` is the sprint slice for this turn
+  - issue `#71` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 25 was added and converted into issue `#69`
+  - Task 26 was added and converted into issue `#71`
 - Review / Demo
-  - show the new closeout fields, memory handoff wording, and guard coverage
+  - show the reusable template, docs link, and guard coverage
 - Retrospective
-  - keep the closeout contract short enough to avoid heavy archival overhead
+  - keep the template small enough to guide, not to become process bloat
 
 ## Verification
 
@@ -74,14 +75,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - define a canonical `PLANS.md` closeout contract in [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
-  - align [`PLANS.md`](./PLANS.md) to the new `Sprint Status` / `Sprint Scope` / `Memory Artifact` / `Resume Point` shape
-  - clarify memory handoff wording in [`tasks/sprint-memory/README.md`](./tasks/sprint-memory/README.md)
-  - lock the contract with [`test/repository_structure.sh`](./test/repository_structure.sh)
+  - add [`templates/plans/PLANS.md`](./templates/plans/PLANS.md) as the canonical reusable starting shape
+  - connect [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md) to the template for new sprint setup
+  - keep [`PLANS.md`](./PLANS.md) and [`test/repository_structure.sh`](./test/repository_structure.sh) aligned with the template contract
 - Retrospective
-  - keep: the turn-scoped sprint rule lightweight and grep-guarded
-  - change: make plan closeout explicit instead of inferring it from merge state
-  - stop: leaving `PLANS.md` in an active-looking state after the sprint is done
+  - keep: turning recurring sprint behavior into reusable repo assets
+  - change: give the next sprint a canonical starting file instead of expecting hand-copy from the last plan
+  - stop: relying on the previous `PLANS.md` as the only source for a new sprint skeleton
 - System Updates
   - backlog: updated
   - plans: updated
@@ -95,6 +95,6 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 - keep
   - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - define closeout fields explicitly instead of relying on implied plan state
+  - make the canonical shape easier to start from, not just easier to verify after the fact
 - stop
-  - leaving merged work behind with a plan that still reads as active
+  - depending on hand-copying the previous sprint plan as the only bootstrap path

--- a/docs/93-scrum-delivery.md
+++ b/docs/93-scrum-delivery.md
@@ -33,6 +33,7 @@ planning の出口は次の状態。
 
 - branch が issue に紐づいている
 - `PLANS.md` が current sprint を説明できる
+- 新しい sprint を始める時は `templates/plans/PLANS.md` を canonical starting shape として使える
 - 誰が product, delivery, review を持つか分かる
 - 最小形なら 3 行程度の sprint note でもよい
 - current turn が 1 sprint か、intentional multi-turn sprint かが明記されている
@@ -152,6 +153,8 @@ ceremony の最小成果物は次でよい。
 
 `PLANS.md` は active sprint の live doc だが、turn-scoped sprint では merge 後に stale な active state を残さない。
 最低限、次の field を持つ。
+
+新しい sprint を始める時は [`templates/plans/PLANS.md`](../templates/plans/PLANS.md) を starting shape とし、issue と branch に合わせて最小限埋めればよい。
 
 - `Sprint Status`
   - `active`

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -428,3 +428,20 @@ Update the Scrum delivery doc, `PLANS.md`, and sprint-memory guidance with a can
 
 Expected Impact:
 The repo keeps a restartable plan surface during active work without leaving misleading active sprint metadata behind after work lands.
+
+## Task 26
+
+Title: Add a reusable PLANS.md template for turn-scoped and multi-turn sprints
+Tracking: #71 (closed)
+
+Problem:
+The repo now defines what `PLANS.md` must contain, but starting a new sprint still depends on hand-copying the current file shape. That keeps the plan contract durable in theory while leaving setup ergonomics inconsistent in practice.
+
+Improvement Idea:
+Add a small reusable template for `PLANS.md` that covers both turn-scoped and intentionally multi-turn sprints, so new work starts from the canonical shape instead of ad hoc copying.
+
+Implementation Hint:
+Add a template file under a durable docs or tasks location, document when to use it from the Scrum delivery docs, and add a narrow structure test so the template keeps the canonical fields and closeout sections.
+
+Expected Impact:
+Starting a sprint becomes faster and more consistent, and the `PLANS.md` contract is easier to follow without drifting.

--- a/tasks/sprint-memory/issue-71.md
+++ b/tasks/sprint-memory/issue-71.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#71`
+- branch: `docs/71-plans-template`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex + Mendel
+  - Docs / Onboarding specialist: Avicenna
+
+## Compressed Memory
+
+- goal: add a reusable `PLANS.md` template so turn-scoped and intentionally multi-turn sprints start from the canonical shape
+- decisions:
+  - keep the solution as a repo template, not a CLI generator
+  - place the reusable asset at `templates/plans/PLANS.md`
+  - keep `docs/93-scrum-delivery.md` as the rule source and point it to the template as the recommended starting shape
+  - guard the template with narrow structure checks for the canonical plan fields and closeout section
+- constraints:
+  - stay within a one-turn docs-and-guards sprint
+  - avoid adding automation or another planning surface
+  - keep the template small enough to guide without turning into process bloat
+- current state: template, docs link, and guards are aligned on the canonical plan shape
+- next likely moves: next sprint can start by copying `templates/plans/PLANS.md` into `PLANS.md` and filling only the current issue slice
+- open questions: whether future ergonomics justify a helper command, or whether the template should remain the stable manual path
+
+## Lane Notes
+
+- Product / Backlog: converted the next plan ergonomics gap into Task 26 and issue `#71`
+- Delivery / Scrum: kept the sprint to one reusable asset plus docs/test integration
+- Implementer: added `templates/plans/PLANS.md`, connected it from `docs/93-scrum-delivery.md`, and guarded it in `test/repository_structure.sh`
+- Reviewer / QA: specialist feedback favored a minimal template over heavier automation
+
+## Retrospective Output
+
+- keep
+  - turning repeated sprint behavior into durable repo assets
+- change
+  - provide a starting template before contributors need to hand-copy the previous plan
+- stop
+  - treating the last `PLANS.md` as the only bootstrap mechanism for the next sprint
+- follow-ups
+  - consider whether a future helper should scaffold `PLANS.md` from this template, but only if manual copying becomes a real drag
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `templates/plans/PLANS.md`
+  - `docs/93-scrum-delivery.md`
+  - `PLANS.md`
+- rerun commands:
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - the template must stay canonical but lightweight; future edits should preserve the short field set and closeout shape

--- a/templates/plans/PLANS.md
+++ b/templates/plans/PLANS.md
@@ -1,0 +1,83 @@
+# AI Dev OS Plan
+
+- Date: `YYYY-MM-DD`
+- Sprint Status: `active`
+- Sprint Scope: `turn-scoped`
+- Active issue: `#<id> short title`
+- Branch: `<type>/<id>-short-name`
+- Memory Artifact: `tasks/sprint-memory/issue-<id>.md` or `not needed in this sprint`
+- Resume Point: `next concrete step`
+
+Use `Sprint Status: multi-turn` and `Sprint Scope: multi-turn` when the issue intentionally spans more than one user turn.
+Use `Sprint Status: closed` after review/demo and retrospective are complete for the sprint.
+
+## North Star
+
+- make AI Dev OS feel like an OS-level workbench for AI workflows: obvious for beginners, faster and deeper for experienced users
+- make it durable enough to still be the right daily tool a year later, not a one-shot workflow wrapper tied to a short-lived trend
+- make the first successful repo-local path obvious in any repo: `ai init -> ai doctor -> ai workflows -> ai start`
+- keep local onboarding as the default story; CI, hosted eval, and runtime pinning stay as later lanes
+- prefer project-local config and vendor-native capability over shell-wrapper reimplementation
+- keep every newcomer-facing surface aligned on the same failure model and next-step guidance
+
+## Current Goal
+
+- `what this sprint is trying to achieve`
+
+## Working Agreement
+
+Active multi-step work follows [`docs/93-scrum-delivery.md`](../../docs/93-scrum-delivery.md).
+
+- start from `tasks/backlog.md`, then commit to an issue-backed sprint slice
+- default to 1 user turn = 1 sprint
+- only span multiple turns when the issue explicitly justifies it
+- end the turn with review/demo evidence and a retrospective outcome
+
+## Sprint Slice
+
+- primary deliverable
+  - `what lands in this sprint`
+- concrete surfaces
+  - [`PLANS.md`](../../PLANS.md)
+- acceptance slice
+  - `verifiable outcome`
+
+## Squad
+
+- Product / Backlog:
+- Delivery / Scrum:
+- Implementer:
+- Reviewer / QA:
+
+## Current Sprint Ceremonies
+
+- Sprint Planning
+  - `issue and branch for this sprint`
+- Backlog Refinement
+  - `next candidate or backlog update`
+- Review / Demo
+  - `what will prove the sprint goal`
+- Retrospective
+  - `what to keep lightweight or change next`
+
+## Verification
+
+- `bash test/repository_structure.sh`
+- `make lint`
+- `make test`
+
+## Closeout
+
+- Review / Demo
+  - `what changed`
+- Retrospective
+  - keep:
+  - change:
+  - stop:
+- System Updates
+  - backlog:
+  - plans:
+  - docs:
+  - tests:
+  - instructions:
+  - ADR:

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -182,6 +182,7 @@ verify_layout_scaffold() {
   assert_dir "$REPO/manifests/packages"
   assert_dir "$REPO/manifests/tmux"
   assert_dir "$REPO/templates/github-actions"
+  assert_dir "$REPO/templates/plans"
   assert_dir "$REPO/templates/ai-trust"
   assert_dir "$REPO/zsh/modules"
   assert_dir "$REPO/tmux/conf.d"
@@ -206,6 +207,7 @@ verify_layout_scaffold() {
   assert_file "$REPO/demo/sample-project/.ai-dev-os/prompts/review.prompt.yml"
   assert_file "$REPO/templates/github-actions/ai-dev-os-pr.yml"
   assert_file "$REPO/templates/github-actions/ai-dev-os-hosted-eval.yml"
+  assert_file "$REPO/templates/plans/PLANS.md"
   assert_file "$REPO/templates/ai-trust/claude-settings.json"
   assert_file "$REPO/templates/ai-trust/codex-config.toml"
   assert_file "$REPO/templates/ai-trust/gemini-settings.json"
@@ -368,6 +370,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/93-scrum-delivery.md does not connect Scrum cadence to PLANS.md"
   grep -Fq "PLANS Closeout Contract" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define the PLANS closeout contract"
+  grep -Fq "templates/plans/PLANS.md" "$REPO/docs/93-scrum-delivery.md" \
+    || fail "docs/93-scrum-delivery.md does not point to the reusable PLANS template"
   grep -Fq "Sprint Status" "$REPO/docs/93-scrum-delivery.md" \
     || fail "docs/93-scrum-delivery.md does not define sprint status in PLANS.md"
   grep -Fq "## Closeout" "$REPO/docs/93-scrum-delivery.md" \
@@ -388,6 +392,18 @@ verify_ai_dev_os_docs() {
     || fail "PLANS.md does not point to tasks/sprint-memory/"
   grep -Fq "## Closeout" "$REPO/PLANS.md" \
     || fail "PLANS.md does not define a closeout section"
+  grep -Fq "Sprint Status" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not define sprint status"
+  grep -Fq "Sprint Scope" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not define sprint scope"
+  grep -Fq "Memory Artifact" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not define memory artifact"
+  grep -Fq "Resume Point" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not define a resume point field"
+  grep -Fq "## Closeout" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not define a closeout section"
+  grep -Fq "multi-turn" "$REPO/templates/plans/PLANS.md" \
+    || fail "templates/plans/PLANS.md does not cover multi-turn sprints"
   grep -Fq "AI Dev OS" "$REPO/docs/90-philosophy.md" \
     || fail "docs/90-philosophy.md does not use the AI Dev OS framing"
   grep -Fq "AI Dev OS control plane" "$REPO/docs/91-state-ownership.md" \


### PR DESCRIPTION
## Summary
- add `templates/plans/PLANS.md` as the canonical reusable sprint-plan starting shape
- point Scrum delivery docs to the template for new sprint setup
- guard the template contract and leave a sprint-memory artifact for this slice

## Related
- Closes #71
- ADR: n/a

## Sprint Context
- Sprint Memory: `tasks/sprint-memory/issue-71.md`
- Review / Demo: `templates/plans/PLANS.md` now provides the canonical `Sprint Status` / `Sprint Scope` / `Memory Artifact` / `Resume Point` / `## Closeout` shape, and `docs/93-scrum-delivery.md` points to it as the starting path for a new sprint
- System Updates:
  - backlog: updated
  - plans: updated
  - docs: updated
  - tests: updated
  - instructions: not needed
  - ADR: not needed

## Checks
- [x] `make test`
- [x] `make lint`
- [x] docs updated if behavior changed
- [x] linked issue has clear acceptance criteria

## Notes
- rollout concerns: low; docs/template/guard only
- follow-up work: consider a helper only if manual template use becomes a real drag