### PR TITLE
feat: teach ai task to summarize pending backlog work before printing the backlog

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #71 `docs: add a reusable PLANS.md template for turn-scoped and multi-turn sprints`
-- Branch: `docs/71-plans-template`
-- Memory Artifact: `tasks/sprint-memory/issue-71.md`
-- Resume Point: reusable plan template landed; start the next sprint from a new issue-backed branch and refresh `PLANS.md` from the template
+- Active issue: #73 `feat: teach ai task to summarize pending backlog work before printing the backlog`
+- Branch: `feat/73-ai-task-pending-summary`
+- Memory Artifact: `tasks/sprint-memory/issue-73.md`
+- Resume Point: ai-task summary upgrade landed; next sprint should start from a new issue-backed branch and refresh this plan from the template
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Add a reusable `PLANS.md` template so turn-scoped and intentionally multi-turn sprints start from the canonical shape instead of ad hoc copying.
+Make `ai task` a better backlog-refinement entrypoint by showing pending work first without losing the full backlog output.
 
 ## Working Agreement
 
@@ -33,18 +33,20 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
 - primary deliverable
-  - a reusable `PLANS.md` template for turn-scoped and multi-turn sprints
+  - a pending-summary upgrade for `ai task`
 - concrete surfaces
-  - [`templates/plans/PLANS.md`](./templates/plans/PLANS.md)
-  - [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md)
+  - [`bin/ai-task`](./bin/ai-task)
+  - [`bin/ai`](./bin/ai)
+  - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`PLANS.md`](./PLANS.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
+  - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - a reusable plan template exists in the repo
-  - the template covers `turn-scoped` and `multi-turn` use
-  - `docs/93-scrum-delivery.md` points to the template as the recommended starting shape
-  - structure tests guard the template and its canonical fields
+  - `ai task` prints a pending summary before the full backlog
+  - the summary includes task number and title for pending tasks
+  - `ai task` says when there are no pending tasks
+  - help/docs wording reflects summary-plus-backlog behavior
 
 ## Squad
 
@@ -58,13 +60,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#71` is the sprint slice for this turn
+  - issue `#73` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 26 was added and converted into issue `#71`
+  - Task 27 was added and converted into issue `#73`
 - Review / Demo
-  - show the reusable template, docs link, and guard coverage
+  - show the pending summary, no-pending fallback, and full backlog preservation
 - Retrospective
-  - keep the template small enough to guide, not to become process bloat
+  - keep `ai task` lightweight and text-only; do not turn it into an interactive task manager
 
 ## Verification
 
@@ -75,13 +77,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - add [`templates/plans/PLANS.md`](./templates/plans/PLANS.md) as the canonical reusable starting shape
-  - connect [`docs/93-scrum-delivery.md`](./docs/93-scrum-delivery.md) to the template for new sprint setup
-  - keep [`PLANS.md`](./PLANS.md) and [`test/repository_structure.sh`](./test/repository_structure.sh) aligned with the template contract
+  - prepend pending-task summary output in [`bin/ai-task`](./bin/ai-task) while preserving the full backlog body
+  - update [`bin/ai`](./bin/ai) and [`docs/40-cli.md`](./docs/40-cli.md) so `ai task` reads as a backlog-refinement entrypoint
+  - cover pending and no-pending cases, plus summary/body ordering, in [`test/ai_cli.sh`](./test/ai_cli.sh)
 - Retrospective
-  - keep: turning recurring sprint behavior into reusable repo assets
-  - change: give the next sprint a canonical starting file instead of expecting hand-copy from the last plan
-  - stop: relying on the previous `PLANS.md` as the only source for a new sprint skeleton
+  - keep: improving operator entrypoints without adding a new command surface
+  - change: test behavior against fixed backlog fixtures instead of the live repo backlog state
+  - stop: relying on raw file dumps for daily backlog refinement
 - System Updates
   - backlog: updated
   - plans: updated
@@ -95,6 +97,6 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 - keep
   - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - make the canonical shape easier to start from, not just easier to verify after the fact
+  - improve operator entrypoints after the planning substrate is stable
 - stop
-  - depending on hand-copying the previous sprint plan as the only bootstrap path
+  - treating `ai task` as a raw file dump when backlog refinement is now part of the operating model

--- a/bin/ai
+++ b/bin/ai
@@ -26,7 +26,7 @@ Main Commands:
   agent         run or inspect a configured agent
   context       build repository context
   doctor        inspect workflow resolution and agent readiness
-  task          show the current backlog
+  task          summarize pending backlog work for refinement and print the backlog
   eval          inspect or validate prompt artifacts
   trust         generate or apply vendor-native trust config
   install       run the OS abstraction install wrapper

--- a/bin/ai-task
+++ b/bin/ai-task
@@ -6,5 +6,43 @@ if [[ -L "$SCRIPT_PATH" ]]; then
   SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
 fi
 BIN_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd -P)"
+BACKLOG_FILE="${AI_TASK_BACKLOG_FILE:-$BIN_DIR/../tasks/backlog.md}"
 
-cat "$BIN_DIR/../tasks/backlog.md"
+if [[ ! -f "$BACKLOG_FILE" ]]; then
+  echo "missing backlog file: $BACKLOG_FILE" >&2
+  exit 1
+fi
+
+pending_tasks=()
+while IFS= read -r pending_task; do
+  pending_tasks+=("$pending_task")
+done < <(
+  awk '
+    /^## Task / {
+      task = $0
+      sub(/^## /, "", task)
+      title = ""
+      next
+    }
+    /^Title: / {
+      title = substr($0, 8)
+      next
+    }
+    /^Tracking: pending$/ {
+      if (task != "" && title != "") {
+        print task ": " title
+      }
+    }
+  ' "$BACKLOG_FILE"
+)
+
+printf 'AI Dev OS Pending Tasks\n'
+printf 'Pending count: %d\n' "${#pending_tasks[@]}"
+if [[ ${#pending_tasks[@]} -eq 0 ]]; then
+  printf -- '- none\n'
+else
+  printf '%s\n' "${pending_tasks[@]}" | sed 's/^/- /'
+fi
+printf '\n'
+
+cat "$BACKLOG_FILE"

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -22,6 +22,7 @@ AI Dev OS の入口は `ai --help` と `ai start`。starter repo で最初に困
 ai --help
 ai init
 ai doctor
+ai task
 ai workflows
 ai agents
 ai-agent --describe --workflow review
@@ -51,6 +52,7 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 
 `ai workflows` は `workflow | default agent | description` を基本に、必要なら fallback chain も含めて確認するための一覧。
 `ai agents` は `agent | provider | role | command | description` を表示する。
+`ai task` は pending backlog task の短い summary を先に出し、その後に full backlog を表示する。backlog refinement や次 sprint 候補の確認を始める時の入口として使う。
 project-local scaffold を作りたい時は `ai init` を使う。
 `ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -445,3 +445,20 @@ Add a template file under a durable docs or tasks location, document when to use
 
 Expected Impact:
 Starting a sprint becomes faster and more consistent, and the `PLANS.md` contract is easier to follow without drifting.
+
+## Task 27
+
+Title: Teach `ai task` to summarize pending backlog work before printing the backlog
+Tracking: #73 (closed)
+
+Problem:
+`ai task` currently dumps `tasks/backlog.md` verbatim. That preserves the raw source of truth, but it makes backlog refinement and next-sprint selection slower because pending work is buried inside the full file.
+
+Improvement Idea:
+Keep `ai task` simple, but prepend a short pending-task summary before the full backlog so the command is useful as a daily backlog-refinement entrypoint.
+
+Implementation Hint:
+Parse task titles and `Tracking:` state from `tasks/backlog.md`, print a compact pending summary first, then print the unchanged backlog body. Update CLI wording and tests to reflect the new behavior.
+
+Expected Impact:
+Operators can use `ai task` to spot next candidates quickly without losing access to the full backlog context.

--- a/tasks/sprint-memory/issue-73.md
+++ b/tasks/sprint-memory/issue-73.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#73`
+- branch: `feat/73-ai-task-pending-summary`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex + Mendel
+  - Docs / Onboarding specialist: Avicenna
+
+## Compressed Memory
+
+- goal: make `ai task` a better backlog-refinement entrypoint by summarizing pending work before printing the full backlog
+- decisions:
+  - keep the existing `ai task` command instead of adding a new backlog subcommand
+  - prepend a short pending summary and then print the unchanged backlog body
+  - make the help/docs text explicitly about backlog refinement and next-sprint selection
+  - test pending and no-pending cases against fixed fixtures so the suite does not depend on the live repo backlog state
+- constraints:
+  - stay within one turn-scoped sprint
+  - avoid turning `ai task` into an interactive task manager
+  - keep the backlog file as the source of truth
+- current state: `ai task` shows pending summary + full backlog, docs/help are updated, and tests cover ordering plus no-pending fallback
+- next likely moves: consider whether backlog refinement needs richer filters later, but only if the text summary stops being enough
+- open questions: whether future backlog scale justifies optional filters without violating the repo's preference for simple text surfaces
+
+## Lane Notes
+
+- Product / Backlog: converted the next operator-experience gap into Task 27 and issue `#73`
+- Delivery / Scrum: kept the sprint limited to one existing command, docs/help wording, and tests
+- Implementer: updated `bin/ai-task`, `bin/ai`, `docs/40-cli.md`, and `test/ai_cli.sh`
+- Reviewer / QA: review feedback tightened the tests around summary-before-body ordering and exclusion of closed tasks from the summary
+
+## Retrospective Output
+
+- keep
+  - improving existing operator entrypoints before adding new command surfaces
+- change
+  - test against fixture backlogs when repo state is expected to change during the sprint
+- stop
+  - treating backlog refinement as a raw file-viewing task only
+- follow-ups
+  - revisit optional filters only if the plain-text summary stops being enough at current backlog scale
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-task`
+  - `docs/40-cli.md`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - if backlog formatting changes substantially, the summary parser and fixture tests will need to move together

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -7,6 +7,8 @@ TEST_REPO="$TMPDIR_ROOT/project"
 GLOBAL_REPO="$TMPDIR_ROOT/global-project"
 INIT_REPO="$TMPDIR_ROOT/init-project"
 STUB_BIN="$TMPDIR_ROOT/bin"
+PENDING_BACKLOG="$TMPDIR_ROOT/pending-backlog.md"
+NO_PENDING_BACKLOG="$TMPDIR_ROOT/no-pending-backlog.md"
 TMUX_LOG="$TMPDIR_ROOT/tmux.log"
 OPEN_LOG="$TMPDIR_ROOT/open.log"
 COPY_LOG="$TMPDIR_ROOT/copy.log"
@@ -79,6 +81,55 @@ workflows:
     default_agent: broken_native
     fallback_agents: missing_native
     description: No viable workflow candidates
+EOF
+
+  cat > "$PENDING_BACKLOG" <<'EOF'
+# AI Dev OS Backlog
+
+Tracking note:
+- `Tracking: #<issue> (closed)` means the task landed in `main` and stays here as historical context.
+- `Tracking: pending` means the task has not been turned into a GitHub Issue yet.
+
+## Task 99
+
+Title: Example pending task
+Tracking: pending
+
+Problem:
+Pending example.
+
+Expected Impact:
+Pending example.
+
+## Task 100
+
+Title: Example closed task
+Tracking: #100 (closed)
+
+Problem:
+Closed example.
+
+Expected Impact:
+Closed example.
+EOF
+
+  cat > "$NO_PENDING_BACKLOG" <<'EOF'
+# AI Dev OS Backlog
+
+Tracking note:
+- `Tracking: #<issue> (closed)` means the task landed in `main` and stays here as historical context.
+- `Tracking: pending` means the task has not been turned into a GitHub Issue yet.
+
+## Task 101
+
+Title: Example closed task
+Tracking: #101 (closed)
+
+Problem:
+Closed example.
+
+Expected Impact:
+Closed example.
 EOF
 }
 
@@ -191,6 +242,7 @@ help_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" -
 [[ "$help_output" == *"[candidates: implementer -> codex -> gemini]"* ]] || fail "ai help did not include workflow candidate metadata"
 [[ "$help_output" == *".ai-dev-os/workflows.yml"* ]] || fail "ai help did not mention project-local overrides"
 [[ "$help_output" == *"doctor        inspect workflow resolution and agent readiness"* ]] || fail "ai help did not list the doctor command"
+[[ "$help_output" == *"task          summarize pending backlog work for refinement and print the backlog"* ]] || fail "ai help did not list the updated task command"
 [[ "$help_output" == *"trust         generate or apply vendor-native trust config"* ]] || fail "ai help did not list the trust command"
 
 agents_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" agents)"
@@ -246,8 +298,24 @@ workflow_describe_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$R
 [[ "$workflow_describe_output" == *"resolution_candidates: reviewer, claude, gemini"* ]] || fail "ai-agent describe missing resolution candidates"
 [[ "$workflow_describe_output" == *"agents_config: $REPO/ai/agents.yml"* ]] || fail "ai-agent did not report the resolved agent config"
 
-task_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" task)"
-[[ "$task_output" == *"AI Dev OS Backlog"* ]] || fail "ai task did not print the backlog"
+task_output="$(cd "$GLOBAL_REPO" && AI_TASK_BACKLOG_FILE="$PENDING_BACKLOG" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" task)"
+[[ "$task_output" == *"AI Dev OS Pending Tasks"* ]] || fail "ai task did not print the pending summary header"
+[[ "$task_output" == *"Pending count: 1"* ]] || fail "ai task did not print the pending task count"
+[[ "$task_output" == *"- Task 99: Example pending task"* ]] || fail "ai task did not summarize pending tasks"
+[[ "$task_output" == *"AI Dev OS Backlog"* ]] || fail "ai task did not print the backlog body"
+task_summary="${task_output%%# AI Dev OS Backlog*}"
+[[ "$task_summary" == *"- Task 99: Example pending task"* ]] || fail "ai task summary did not include the pending task before the backlog body"
+[[ "$task_summary" != *"Example closed task"* ]] || fail "ai task summary included a closed task"
+[[ "$task_output" == *"Title: Example closed task"* ]] || fail "ai task did not preserve the closed task in the backlog body"
+[[ "$task_output" == *"Tracking: #100 (closed)"* ]] || fail "ai task did not preserve closed-task tracking in the backlog body"
+
+no_pending_task_output="$(AI_TASK_BACKLOG_FILE="$NO_PENDING_BACKLOG" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-task")"
+[[ "$no_pending_task_output" == *"AI Dev OS Pending Tasks"* ]] || fail "ai-task did not print the no-pending summary header"
+[[ "$no_pending_task_output" == *"Pending count: 0"* ]] || fail "ai-task did not print the zero pending count"
+[[ "$no_pending_task_output" == *"- none"* ]] || fail "ai-task did not explain the no-pending case"
+[[ "$no_pending_task_output" == *"AI Dev OS Backlog"* ]] || fail "ai-task did not preserve the backlog output in the no-pending case"
+no_pending_summary="${no_pending_task_output%%# AI Dev OS Backlog*}"
+[[ "$no_pending_summary" == *"- none"* ]] || fail "ai-task did not keep the no-pending marker before the backlog body"
 
 PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-context" --repo "$TEST_REPO" >/dev/null
 [[ -f "$TEST_REPO/.context/summary.md" ]] || fail "ai-context did not create summary.md"


### PR DESCRIPTION
## Summary
- prepend a pending-task summary to `ai task` while preserving the full backlog body
- update CLI/docs wording so `ai task` reads as a backlog-refinement entrypoint
- test pending and no-pending cases with fixture backlogs instead of the live repo backlog state

## Related
- Closes #73
- ADR: n/a

## Sprint Context
- Sprint Memory: `tasks/sprint-memory/issue-73.md`
- Review / Demo: `ai task` now prints `AI Dev OS Pending Tasks` and a pending count before the unchanged backlog body; the docs and help text frame it as the backlog-refinement entrypoint
- System Updates:
  - backlog: updated
  - plans: updated
  - docs: updated
  - tests: updated
  - instructions: not needed
  - ADR: not needed

## Checks
- [x] `make test`
- [x] `make lint`
- [x] docs updated if behavior changed
- [x] linked issue has clear acceptance criteria

## Notes
- rollout concerns: low; output-only improvement on an existing command
- follow-up work: consider optional filters only if the plain-text summary stops being enough