### PR TITLE
docs: add beginner-first next-step guidance to ai doctor

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #77 `docs: teach ai --help to show the beginner path before deeper commands`
-- Branch: `docs/77-ai-help-beginner-path`
-- Memory Artifact: `tasks/sprint-memory/issue-77.md`
-- Resume Point: ai help guidance is aligned; start the next sprint from a new issue-backed branch and refresh this plan from the template
+- Active issue: #79 `docs: add beginner-first next-step guidance to ai doctor`
+- Branch: `docs/79-ai-doctor-next-steps`
+- Memory Artifact: `tasks/sprint-memory/issue-79.md`
+- Resume Point: ai-doctor next-step guidance is aligned; start the next sprint from a new issue-backed branch and refresh this plan from the template
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Make `ai --help` a beginner-first discovery surface by showing the recommended next-step path before deeper commands.
+Make `ai doctor` a better recovery surface by ending with beginner-first next-step guidance for healthy, warn, and fail outcomes.
 
 ## Working Agreement
 
@@ -33,19 +33,19 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
 - primary deliverable
-  - beginner-first `ai --help` guidance
+  - beginner-first `ai doctor` next-step guidance
 - concrete surfaces
-  - [`bin/ai`](./bin/ai)
+  - [`bin/ai-doctor`](./bin/ai-doctor)
   - [`docs/40-cli.md`](./docs/40-cli.md)
-  - [`PLANS.md`](./PLANS.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
-  - [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - [`PLANS.md`](./PLANS.md)
+  - [`test/ai_doctor.sh`](./test/ai_doctor.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
 - acceptance slice
-  - `ai --help` includes a short beginner-first path
-  - starter-repo guidance puts `ai doctor` / `ai workflows` ahead of deeper commands
-  - deeper commands remain visible after the first-steps section
-  - tests lock the help ordering
+  - `ai doctor` prints a compact next-step block at the end
+  - healthy output points to `ai workflows` before `ai start`
+  - warn output keeps beginner-first ordering and can point to deeper inspection after `ai workflows`
+  - fail output tells users to fix gaps and rerun `ai doctor` before `ai start`
 
 ## Squad
 
@@ -59,13 +59,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#77` is the sprint slice for this turn
+  - issue `#79` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 29 was added and converted into issue `#77`
+  - Task 30 was added and converted into issue `#79`
 - Review / Demo
-  - show the new `First Steps` section in `ai --help` and its ordering
+  - show the new `ai doctor` next-step block for healthy, warn, and fail cases
 - Retrospective
-  - keep `ai --help` compact while making the next step obvious
+  - keep `ai doctor` terminal-short and explicit about what to do next
 
 ## Verification
 
@@ -76,13 +76,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - add a `First Steps` block to [`bin/ai`](./bin/ai) with runtime repo, starter repo, and deeper-use paths
-  - align [`docs/40-cli.md`](./docs/40-cli.md) and [`README.md`](./README.md) with the new beginner-first role of `ai --help`
-  - lock the line ordering in [`test/ai_cli.sh`](./test/ai_cli.sh) and the docs wording in [`test/repository_structure.sh`](./test/repository_structure.sh)
+  - add an outcome-based `Next Steps` footer to [`bin/ai-doctor`](./bin/ai-doctor)
+  - keep healthy output on `ai workflows -> ai start`, warn output on `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`, and fail output on `fix -> rerun ai doctor -> ai workflows`
+  - align [`docs/40-cli.md`](./docs/40-cli.md) and lock the footer ordering in [`test/ai_doctor.sh`](./test/ai_doctor.sh)
 - Retrospective
-  - keep: upgrade the most common entry surfaces before adding new ones
-  - change: treat docs/help shape as a tested contract, not just a copy edit
-  - stop: leaving `ai --help` as a flat command catalog after the rest of the repo moved to guided next steps
+  - keep: extend beginner-first guidance to recovery surfaces after discovery and startup surfaces are aligned
+  - change: treat the exact last lines of diagnostic output as part of the contract when the task is specifically about next steps
+  - stop: ending the canonical recovery command with no clear next action
 - System Updates
   - backlog: updated
   - plans: updated
@@ -96,6 +96,6 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 - keep
   - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - align top-level CLI discovery with the same beginner path used in runtime messages
+  - align the recovery surface with the same beginner path used in discovery and startup messages
 - stop
-  - treating `ai --help` as a flat catalog after the rest of the repo moved to guided next steps
+  - leaving `ai doctor` as a raw diagnostic dump after the rest of the repo moved to guided next steps

--- a/bin/ai-doctor
+++ b/bin/ai-doctor
@@ -221,6 +221,8 @@ report_workflow() {
     overall_exit=1
   elif [[ "$selected_agent" != "${candidates[0]}" ]]; then
     workflow_status="WARN fallback to $selected_agent"
+    any_warn=1
+    [[ -z "$warned_workflow" ]] && warned_workflow="$workflow_name"
   fi
 
   printf '  status: %s\n' "$workflow_status"
@@ -333,7 +335,29 @@ report_agent() {
 
   [[ -n "$docs_url" ]] && printf '  docs: %s\n' "$docs_url"
   printf '  status: %s\n' "$agent_status"
+  [[ "$agent_status" == "WARN" ]] && any_warn=1
   printf '\n'
+}
+
+print_next_steps() {
+  printf 'Next Steps\n'
+
+  if [[ "$overall_exit" -ne 0 ]]; then
+    printf '  - fix the reported gaps above\n'
+    printf '  - rerun: ai doctor\n'
+    printf '  - inspect available workflows: ai workflows\n'
+    return
+  fi
+
+  printf '  - next: ai workflows\n'
+  if [[ -n "$warned_workflow" ]]; then
+    printf '  - optional deeper check: ai-agent --describe --workflow %s\n' "$warned_workflow"
+  fi
+  if [[ "$any_warn" -eq 1 ]]; then
+    printf '  - if the warnings look acceptable, next: ai start\n'
+  else
+    printf '  - next: ai start\n'
+  fi
 }
 
 target_path="$PWD"
@@ -376,6 +400,8 @@ context_checked="0"
 context_ready="0"
 context_error=""
 overall_exit=0
+any_warn=0
+warned_workflow=""
 
 if [[ -n "$workflow_filter" ]] && ! ai_has_named_key "$WORKFLOWS_FILE" workflows "$workflow_filter"; then
   echo "unknown workflow: $workflow_filter" >&2
@@ -412,5 +438,7 @@ else
     report_agent "$listed_agent"
   done < <(ai_section_keys "$AGENTS_FILE" agents)
 fi
+
+print_next_steps
 
 exit "$overall_exit"

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -54,7 +54,7 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 `ai task` は pending backlog task の短い summary を先に出し、その後に full backlog を表示する。backlog refinement や次 sprint 候補の確認を始める時の入口として使う。
 `ai start` の起動後は、まず `ai doctor` と `ai workflows` を見れば beginner path に戻りやすい。
 project-local scaffold を作りたい時は `ai init` を使う。
-`ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。
+`ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start`、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`、fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。
 launch 挙動は `ai-agent --describe <agent>` や `ai-agent --describe --workflow <name>` で確認できる。
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -496,3 +496,20 @@ Add a small `First Steps` section to `bin/ai`, update CLI docs wording, and lock
 
 Expected Impact:
 The most common CLI discovery surface tells the same story as the rest of the repo, which reduces onboarding drift and makes the daily entrypoint more trustworthy.
+
+## Task 30
+
+Title: Add beginner-first next-step guidance to `ai doctor`
+Tracking: #79 (closed)
+
+Problem:
+`ai doctor` is now the canonical first response for starter-repo troubleshooting, but its output still stops at diagnosis. That makes the most important recovery surface weaker than the rest of the beginner path, which already teaches clear next steps.
+
+Improvement Idea:
+Keep the existing diagnostics intact, but end `ai doctor` with a short outcome-based next-step block so healthy, warn, and fail cases tell users what to do next.
+
+Implementation Hint:
+Add a compact footer to `bin/ai-doctor`, update CLI docs wording, and cover healthy, warn, and fail cases in tests without blurring `ai doctor` and `make doctor`.
+
+Expected Impact:
+Users who run `ai doctor` can move from diagnosis to the right next action faster, which makes beginner recovery more consistent and less guessy.

--- a/tasks/sprint-memory/issue-79.md
+++ b/tasks/sprint-memory/issue-79.md
@@ -1,0 +1,70 @@
+# Sprint
+
+- issue: `#79`
+- branch: `docs/79-ai-doctor-next-steps`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex + Mendel
+  - Docs / Onboarding specialist: Avicenna
+
+## Compressed Memory
+
+- goal: make `ai doctor` end with beginner-first next-step guidance so diagnosis leads to the right next action
+- decisions:
+  - keep existing diagnostics unchanged and append a compact `Next Steps` footer
+  - use three outcomes: healthy, warn, fail
+  - healthy: `ai workflows -> ai start`
+  - warn: `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`
+  - fail: `fix the reported gaps above -> rerun ai doctor -> ai workflows`
+  - treat the final footer lines as part of the contract and test them as end-of-output behavior
+- constraints:
+  - stay within one turn-scoped sprint
+  - do not blur `ai doctor` and `make doctor`
+  - do not imply that `ai doctor` fixes problems automatically
+- current state: `ai doctor` now ends with outcome-based next steps, docs match the three cases, and tests cover healthy/warn/fail ordering plus footer placement
+- next likely moves: inspect whether `make doctor` and troubleshooting docs need a similar compact outcome summary without collapsing the AI-vs-host boundary
+- open questions: whether warn output should eventually name the selected workflow more prominently when no fallback was involved
+
+## Lane Notes
+
+- Product / Backlog: converted the next recovery-surface gap into Task 30 and issue `#79`
+- Delivery / Scrum: kept the sprint to one diagnostic surface, one docs line, and tests
+- Implementer: updated `bin/ai-doctor`, `docs/40-cli.md`, `test/ai_doctor.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: review feedback strengthened both footer placement checks and warn/fail docs coverage
+
+## Retrospective Output
+
+- keep
+  - aligning the highest-traffic runtime surfaces one by one against the same beginner path
+- change
+  - test footer placement explicitly when the feature is “what happens at the end”
+- stop
+  - letting diagnostic commands end without a clear recovery or next-step path
+- follow-ups
+  - inspect `make doctor` and troubleshooting surfaces next for the same outcome-summary gap
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-doctor`
+  - `docs/40-cli.md`
+  - `test/ai_doctor.sh`
+- rerun commands:
+  - `bash test/ai_doctor.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - if diagnostic statuses or wording change later, the footer rules and end-of-output assertions need to move together

--- a/test/ai_doctor.sh
+++ b/test/ai_doctor.sh
@@ -178,6 +178,35 @@ doctor_output="$(
 [[ "$doctor_output" == *"agent: claude_native"* ]] || fail "ai doctor did not report claude native diagnostics"
 [[ "$doctor_output" == *"mcp_config: WARN $TEST_REPO/.claude/settings.json (run: ai trust init claude --project --repo $TEST_REPO)"* ]] || fail "ai doctor did not report project-scoped MCP config"
 [[ "$doctor_output" == *"project_extensions: WARN $TEST_REPO/.claude/agents/ (create the directory and add vendor-native project extensions if needed)"* ]] || fail "ai doctor did not report missing project extensions"
+[[ "$doctor_output" == *"Next Steps"* ]] || fail "ai doctor did not print next steps for the fail case"
+[[ "$doctor_output" == *"fix the reported gaps above"* ]] || fail "ai doctor did not explain the fail-case remediation"
+[[ "$doctor_output" == *"rerun: ai doctor"* ]] || fail "ai doctor did not explain the fail-case rerun step"
+[[ "$doctor_output" == *"inspect available workflows: ai workflows"* ]] || fail "ai doctor did not explain the fail-case workflow inspection step"
+[[ "$doctor_output" != *"next: ai start"* ]] || fail "ai doctor should not suggest ai start in the fail case"
+[[ "$(printf '%s\n' "$doctor_output" | tail -n 1)" == "  - inspect available workflows: ai workflows" ]] || fail "ai doctor did not keep fail-case next steps at the end of the output"
+
+warn_output="$(
+  cd "$TEST_REPO" && HOME="$TEST_HOME" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-doctor" --workflow broken_fallback --agent local_reviewer
+)"
+[[ "$warn_output" == *"status: WARN fallback to local_reviewer"* ]] || fail "warn ai-doctor output did not include fallback status"
+[[ "$warn_output" == *"Next Steps"* ]] || fail "warn ai-doctor output did not print next steps"
+[[ "$warn_output" == *"next: ai workflows"* ]] || fail "warn ai-doctor output did not point to ai workflows first"
+[[ "$warn_output" == *"optional deeper check: ai-agent --describe --workflow broken_fallback"* ]] || fail "warn ai-doctor output did not include deeper workflow inspection"
+[[ "$warn_output" == *"if the warnings look acceptable, next: ai start"* ]] || fail "warn ai-doctor output did not keep ai start behind the warning check"
+[[ "$(printf '%s\n' "$warn_output" | tail -n 1)" == "  - if the warnings look acceptable, next: ai start" ]] || fail "warn ai-doctor output did not keep next steps at the end of the output"
+
+mkdir -p "$TEST_REPO/.gemini" "$TEST_HOME/.gemini"
+touch "$TEST_REPO/.gemini/settings.json" "$TEST_HOME/.gemini/settings.json"
+
+healthy_output="$(
+  cd "$TEST_REPO" && HOME="$TEST_HOME" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-doctor" --workflow native --agent local_reviewer
+)"
+[[ "$healthy_output" == *"status: OK"* ]] || fail "healthy ai-doctor output did not report OK status"
+[[ "$healthy_output" == *"Next Steps"* ]] || fail "healthy ai-doctor output did not print next steps"
+[[ "$healthy_output" == *"next: ai workflows"* ]] || fail "healthy ai-doctor output did not point to ai workflows first"
+[[ "$healthy_output" == *"next: ai start"* ]] || fail "healthy ai-doctor output did not point to ai start second"
+[[ "$healthy_output" != *"if the warnings look acceptable"* ]] || fail "healthy ai-doctor output should not print warning-specific guidance"
+[[ "$(printf '%s\n' "$healthy_output" | tail -n 1)" == "  - next: ai start" ]] || fail "healthy ai-doctor output did not keep next steps at the end of the output"
 
 filtered_output="$(
   cd "$TEST_REPO" && HOME="$TEST_HOME" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-doctor" --workflow native --agent local_reviewer

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -286,6 +286,12 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not keep the starter repo first-steps guidance"
   grep -Fq "\`deeper use\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not preserve deeper-use guidance after first steps"
+  grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document healthy ai doctor next steps"
+  grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document warn-case ai doctor next steps"
+  grep -Fq "fail path では \`fix the reported gaps above -> rerun ai doctor -> ai workflows\`" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document fail-case ai doctor next steps"
   grep -Fq "AI_DEV_OS_PROJECT_ROOTS" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document AI Dev OS project root aliases"
   grep -Fq "prompt_file" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- add an outcome-based `Next Steps` footer to `ai doctor`
- document healthy, warn, and fail next-step paths in the CLI docs
- lock footer ordering and next-step wording with tests

## Related
- Closes #79
- ADR: n/a

## Sprint Context
- Sprint Memory: `tasks/sprint-memory/issue-79.md`
- Review / Demo: `ai doctor` now ends with healthy/warn/fail next-step guidance instead of stopping at diagnostics, and the tests lock both footer placement and outcome-specific wording
- System Updates:
  - backlog: updated
  - plans: updated
  - docs: updated
  - tests: updated
  - instructions: not needed
  - ADR: not needed

## Checks
- [x] `make test`
- [x] `make lint`
- [x] docs updated if behavior changed
- [x] linked issue has clear acceptance criteria

## Notes
- rollout concerns: low; diagnostic behavior is unchanged and only the footer/docs/tests were added
- follow-up work: inspect `make doctor` and troubleshooting surfaces for the same outcome-summary consistency gap