### PR TITLE
docs: align unknown-command recovery in ai with the beginner path

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #79 `docs: add beginner-first next-step guidance to ai doctor`
-- Branch: `docs/79-ai-doctor-next-steps`
-- Memory Artifact: `tasks/sprint-memory/issue-79.md`
-- Resume Point: ai-doctor next-step guidance is aligned; start the next sprint from a new issue-backed branch and refresh this plan from the template
+- Active issue: #81 `docs: align unknown-command recovery in ai with the beginner path`
+- Branch: `docs/81-ai-unknown-command-guidance`
+- Memory Artifact: `tasks/sprint-memory/issue-81.md`
+- Resume Point: unknown-command recovery is aligned; start the next sprint from a new issue-backed branch and refresh this plan from the template
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Make `ai doctor` a better recovery surface by ending with beginner-first next-step guidance for healthy, warn, and fail outcomes.
+Align the generic unknown-command recovery path in `ai` with the same beginner-first order used by help, start, and doctor.
 
 ## Working Agreement
 
@@ -33,19 +33,18 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
 - primary deliverable
-  - beginner-first `ai doctor` next-step guidance
+  - beginner-first unknown-command recovery guidance
 - concrete surfaces
-  - [`bin/ai-doctor`](./bin/ai-doctor)
+  - [`bin/ai`](./bin/ai)
   - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_doctor.sh`](./test/ai_doctor.sh)
-  - [`test/repository_structure.sh`](./test/repository_structure.sh)
+  - [`test/ai_cli.sh`](./test/ai_cli.sh)
 - acceptance slice
-  - `ai doctor` prints a compact next-step block at the end
-  - healthy output points to `ai workflows` before `ai start`
-  - warn output keeps beginner-first ordering and can point to deeper inspection after `ai workflows`
-  - fail output tells users to fix gaps and rerun `ai doctor` before `ai start`
+  - unknown-command output points to `ai doctor` before `ai workflows`
+  - workflow-alias discovery remains visible in the fallback output
+  - tests lock the fallback ordering
+  - any touched docs keep the same recovery order
 
 ## Squad
 
@@ -59,13 +58,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#79` is the sprint slice for this turn
+  - issue `#81` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 30 was added and converted into issue `#79`
+  - Task 31 was added and converted into issue `#81`
 - Review / Demo
-  - show the new `ai doctor` next-step block for healthy, warn, and fail cases
+  - show the unknown-command recovery order and keep workflow discovery visible
 - Retrospective
-  - keep `ai doctor` terminal-short and explicit about what to do next
+  - keep the unknown-command path short and terminal-friendly
 
 ## Verification
 
@@ -76,13 +75,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - add an outcome-based `Next Steps` footer to [`bin/ai-doctor`](./bin/ai-doctor)
-  - keep healthy output on `ai workflows -> ai start`, warn output on `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`, and fail output on `fix -> rerun ai doctor -> ai workflows`
-  - align [`docs/40-cli.md`](./docs/40-cli.md) and lock the footer ordering in [`test/ai_doctor.sh`](./test/ai_doctor.sh)
+  - update [`bin/ai`](./bin/ai) so unknown-command fallback points to `ai doctor` before `ai workflows`
+  - keep workflow-alias discovery visible after the doctor-first remediation
+  - align [`docs/40-cli.md`](./docs/40-cli.md) and lock the fallback order in [`test/ai_cli.sh`](./test/ai_cli.sh)
 - Retrospective
-  - keep: extend beginner-first guidance to recovery surfaces after discovery and startup surfaces are aligned
-  - change: treat the exact last lines of diagnostic output as part of the contract when the task is specifically about next steps
-  - stop: ending the canonical recovery command with no clear next action
+  - keep: close the broadest fallback paths after the stronger happy-path surfaces are aligned
+  - change: add a narrow docs guard when a recovery phrase becomes part of the canonical CLI story
+  - stop: letting generic fallback surfaces lag behind the guided beginner path
 - System Updates
   - backlog: updated
   - plans: updated
@@ -96,6 +95,6 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 - keep
   - treating workflow rules as repo artifacts, not just chat habits
 - change
-  - align the recovery surface with the same beginner path used in discovery and startup messages
+  - align generic fallback paths with the same beginner path used in the stronger entry surfaces
 - stop
-  - leaving `ai doctor` as a raw diagnostic dump after the rest of the repo moved to guided next steps
+  - leaving one broad fallback path on an older, thinner recovery story

--- a/bin/ai
+++ b/bin/ai
@@ -132,6 +132,7 @@ case "$command_name" in
       exec "$BIN_DIR/ai-agent" --workflow "$command_name" "$@"
     fi
     echo "unknown ai command: $command_name" >&2
+    echo "run \`ai doctor\` to diagnose repo/runtime readiness first" >&2
     echo "run \`ai workflows\` to see available workflow aliases and descriptions" >&2
     echo "repo-local overrides may add commands via .ai-dev-os/workflows.yml" >&2
     usage >&2

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -31,6 +31,7 @@ ai start
 `ai --help` は main commands に加えて、runtime repo path の `ai doctor -> ai start`、starter repo path の `ai init -> ai doctor -> ai workflows -> ai start`、その後ろに `deeper use` を表示する。
 workflow に fallback chain がある場合は、`ai --help` がその discovery の入口になる。
 repo に `.ai-dev-os/workflows.yml` や `.ai-dev-os/agents.yml` があれば、その override も discovery output に反映される。
+unknown command に当たった時も、`ai` は `ai doctor` を先に、`ai workflows` を次に案内する。
 
 ## beginner surface と deeper surface
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -513,3 +513,20 @@ Add a compact footer to `bin/ai-doctor`, update CLI docs wording, and cover heal
 
 Expected Impact:
 Users who run `ai doctor` can move from diagnosis to the right next action faster, which makes beginner recovery more consistent and less guessy.
+
+## Task 31
+
+Title: Align unknown-command recovery in `ai` with the beginner path
+Tracking: #81 (closed)
+
+Problem:
+The repo's main entry surfaces now guide users through `ai doctor`, `ai workflows`, and `ai start`, but the generic unknown-command fallback in `ai` still behaves like an older thin error path. That leaves one broad recovery surface out of sync with the current beginner path.
+
+Improvement Idea:
+Keep the unknown-command path short, but make it point users to `ai doctor` and `ai workflows` before deeper commands so the fallback story matches the rest of the CLI.
+
+Implementation Hint:
+Adjust the unknown-command stderr in `bin/ai`, update any lightweight CLI wording if needed, and lock the ordering down in tests.
+
+Expected Impact:
+Even when users type the wrong command, the top-level CLI still pushes them toward the same beginner-first recovery flow as the other entry surfaces.

--- a/tasks/sprint-memory/issue-81.md
+++ b/tasks/sprint-memory/issue-81.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#81`
+- branch: `docs/81-ai-unknown-command-guidance`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: align the broad unknown-command fallback in `ai` with the same beginner-first recovery order used by help, start, and doctor
+- decisions:
+  - keep the fallback short and stderr-only
+  - point users to `ai doctor` first, then `ai workflows`
+  - keep workflow-alias discovery visible after the doctor-first remediation
+  - add a narrow docs line and guard so the fallback story does not drift
+- constraints:
+  - stay within one turn-scoped sprint
+  - avoid redesigning `ai --help` or adding interactive command suggestions
+  - do not hide existing workflow-alias hints
+- current state: unknown-command fallback now suggests `ai doctor` before `ai workflows`, docs reflect that, and tests lock the ordering
+- next likely moves: inspect whether top-level docs still slightly over-compress the `ai --help` / `ai doctor` / `ai start` relationship
+- open questions: whether future CLI growth needs an explicit “common recovery paths” doc section, or whether the current lightweight wording is enough
+
+## Lane Notes
+
+- Product / Backlog: converted the remaining generic-fallback gap into Task 31 and issue `#81`
+- Delivery / Scrum: kept the sprint to one stderr path, one docs line, and tests
+- Implementer: updated `bin/ai`, `docs/40-cli.md`, `test/ai_cli.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: no extra specialist changes were needed after the ordering and docs guard landed
+
+## Retrospective Output
+
+- keep
+  - finishing consistency work by closing the broadest fallback surfaces, not only the happy paths
+- change
+  - add lightweight docs guards whenever a CLI recovery phrase becomes canonical
+- stop
+  - leaving generic fallback paths behind after stronger surfaces are cleaned up
+- follow-ups
+  - review top-level README wording again if the remaining foundation count needs another reduction sprint
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai`
+  - `docs/40-cli.md`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - if fallback wording changes later, the stderr order and docs guard should move together

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -451,6 +451,11 @@ unusable_failure="$(
 [[ "$unusable_failure" == *"run: ai doctor"* ]] || fail "unusable workflow did not suggest ai doctor"
 
 unknown_output="$(PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" nope 2>&1 >/dev/null || true)"
+[[ "$unknown_output" == *"run \`ai doctor\` to diagnose repo/runtime readiness first"* ]] || fail "unknown ai command did not include doctor remediation"
 [[ "$unknown_output" == *"run \`ai workflows\` to see available workflow aliases and descriptions"* ]] || fail "unknown ai command did not include workflow remediation"
+unknown_doctor_line="$(printf '%s\n' "$unknown_output" | rg '^run `ai doctor`' -n)"
+unknown_workflows_line="$(printf '%s\n' "$unknown_output" | rg '^run `ai workflows`' -n)"
+[[ -n "$unknown_doctor_line" && -n "$unknown_workflows_line" ]] || fail "unknown ai command did not print ordered recovery lines"
+[[ "${unknown_doctor_line%%:*}" -lt "${unknown_workflows_line%%:*}" ]] || fail "unknown ai command did not point to ai doctor before ai workflows"
 
 echo "ai cli test passed"

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -286,6 +286,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not keep the starter repo first-steps guidance"
   grep -Fq "\`deeper use\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not preserve deeper-use guidance after first steps"
+  grep -Fq "unknown command に当たった時も" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document unknown-command recovery guidance"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document healthy ai doctor next steps"
   grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- make unknown `ai` commands point to `ai doctor` before `ai workflows`
- keep workflow-alias discovery visible after the doctor-first remediation
- lock the fallback order and docs wording with tests

## Related
- Closes #81
- ADR: n/a

## Sprint Context
- Sprint Memory: `tasks/sprint-memory/issue-81.md`
- Review / Demo: unknown-command fallback now suggests `ai doctor` first, then `ai workflows`, and the tests lock the stderr order plus docs wording
- System Updates:
  - backlog: updated
  - plans: updated
  - docs: updated
  - tests: updated
  - instructions: not needed
  - ADR: not needed

## Checks
- [x] `make test`
- [x] `make lint`
- [x] docs updated if behavior changed
- [x] linked issue has clear acceptance criteria

## Notes
- rollout concerns: low; this only changes the generic unknown-command recovery text
- follow-up work: reassess remaining top-level README consistency if we want one more foundation-tightening sprint