### PR TITLE
docs: add next-step guidance to ai workflows

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #81 `docs: align unknown-command recovery in ai with the beginner path`
-- Branch: `docs/81-ai-unknown-command-guidance`
-- Memory Artifact: `tasks/sprint-memory/issue-81.md`
-- Resume Point: unknown-command recovery is aligned; start the next sprint from a new issue-backed branch and refresh this plan from the template
+- Active issue: #83 `docs: add beginner-first next-step guidance to ai workflows`
+- Branch: `docs/83-ai-workflows-next-steps`
+- Memory Artifact: `tasks/sprint-memory/issue-83.md`
+- Resume Point: `ai workflows` next-step guidance landed; start the next sprint from a fresh issue-backed branch
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align the generic unknown-command recovery path in `ai` with the same beginner-first order used by help, start, and doctor.
+Make `ai workflows` act like a real beginner-path bridge instead of a flat metadata dump.
 
 ## Working Agreement
 
@@ -32,19 +32,20 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 
 ## Sprint Slice
 
-- primary deliverable
-  - beginner-first unknown-command recovery guidance
-- concrete surfaces
-  - [`bin/ai`](./bin/ai)
+  - primary deliverable
+  - beginner-first next-step guidance for `ai workflows`
+  - concrete surfaces
+  - [`bin/ai-agent`](./bin/ai-agent)
   - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
   - [`test/ai_cli.sh`](./test/ai_cli.sh)
-- acceptance slice
-  - unknown-command output points to `ai doctor` before `ai workflows`
-  - workflow-alias discovery remains visible in the fallback output
-  - tests lock the fallback ordering
-  - any touched docs keep the same recovery order
+  - [`test/repository_structure.sh`](./test/repository_structure.sh)
+  - acceptance slice
+  - `ai workflows` ends with a compact next-step footer
+  - the footer points to `ai-agent --describe --workflow <name>` before `ai start`
+  - tests lock the footer wording and order
+  - docs explain the new guidance without blurring `ai doctor` and `ai workflows`
 
 ## Squad
 
@@ -58,16 +59,17 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#81` is the sprint slice for this turn
+  - issue `#83` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 31 was added and converted into issue `#81`
+  - Task 32 was added and converted into issue `#83`
 - Review / Demo
-  - show the unknown-command recovery order and keep workflow discovery visible
+  - show the `ai workflows` footer order: inspect one workflow, then continue with `ai start`
 - Retrospective
-  - keep the unknown-command path short and terminal-friendly
+  - keep discovery surfaces short and ordered
 
 ## Verification
 
+- `bash test/ai_cli.sh`
 - `bash test/repository_structure.sh`
 - `make lint`
 - `make test`
@@ -75,13 +77,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - update [`bin/ai`](./bin/ai) so unknown-command fallback points to `ai doctor` before `ai workflows`
-  - keep workflow-alias discovery visible after the doctor-first remediation
-  - align [`docs/40-cli.md`](./docs/40-cli.md) and lock the fallback order in [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - update [`bin/ai-agent`](./bin/ai-agent) so `ai workflows` ends with compact next-step guidance
+  - keep workflow inspection ahead of workspace launch in both CLI output and docs
+  - lock the footer wording and order in [`test/ai_cli.sh`](./test/ai_cli.sh)
 - Retrospective
-  - keep: close the broadest fallback paths after the stronger happy-path surfaces are aligned
-  - change: add a narrow docs guard when a recovery phrase becomes part of the canonical CLI story
-  - stop: letting generic fallback surfaces lag behind the guided beginner path
+  - keep: close beginner-path gaps in the order users actually hit the surfaces
+  - change: add a small next-step contract once a discovery command becomes part of the canonical path
+  - stop: treating `ai workflows` like a raw metadata dump after it became a guided beginner-step
 - System Updates
   - backlog: updated
   - plans: updated
@@ -93,8 +95,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - treating workflow rules as repo artifacts, not just chat habits
+  - treating workflow discovery surfaces as part of the guided beginner path
 - change
-  - align generic fallback paths with the same beginner path used in the stronger entry surfaces
+  - align the middle of the beginner path after the top-level entry surfaces are consistent
 - stop
-  - leaving one broad fallback path on an older, thinner recovery story
+  - leaving `ai workflows` as a raw catalog when the repo now treats it as a core next step

--- a/bin/ai-agent
+++ b/bin/ai-agent
@@ -248,6 +248,9 @@ list_workflows() {
   done < <(ai_section_keys "$WORKFLOWS_FILE" workflows)
 
   printf 'source: %s\n' "$WORKFLOWS_FILE"
+  printf '\nNext Steps:\n'
+  printf '  - inspect a workflow: ai-agent --describe --workflow <name>\n'
+  printf '  - then continue the beginner path: ai start\n'
 }
 
 config_kind=""

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -50,7 +50,7 @@ unknown command に当たった時も、`ai` は `ai doctor` を先に、`ai wor
 一時的な wrapper ではなく、長く使う daily tool として surface を整理する。
 trust 設定は beginner surface の常時コマンドというより、`ai doctor` が trust gap を示した時の remediation として使う。
 
-`ai workflows` は `workflow | default agent | description` を基本に、必要なら fallback chain も含めて確認するための一覧。
+`ai workflows` は `workflow | default agent | description` を基本に、必要なら fallback chain も含めて確認するための一覧。一覧を見たあとは、必要なら `ai-agent --describe --workflow <name>` で 1 つの workflow を深掘りし、その次に `ai start` へ進めば beginner path に戻りやすい。
 `ai agents` は `agent | provider | role | command | description` を表示する。
 `ai task` は pending backlog task の短い summary を先に出し、その後に full backlog を表示する。backlog refinement や次 sprint 候補の確認を始める時の入口として使う。
 `ai start` の起動後は、まず `ai doctor` と `ai workflows` を見れば beginner path に戻りやすい。

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -530,3 +530,20 @@ Adjust the unknown-command stderr in `bin/ai`, update any lightweight CLI wordin
 
 Expected Impact:
 Even when users type the wrong command, the top-level CLI still pushes them toward the same beginner-first recovery flow as the other entry surfaces.
+
+## Task 32
+
+Title: Add beginner-first next-step guidance to `ai workflows`
+Tracking: #83 (closed)
+
+Problem:
+`ai workflows` is now part of the canonical beginner path, but the command still behaves like a flat workflow catalog with no explicit next-step guidance. That leaves the middle of the newcomer flow thinner than the surrounding CLI surfaces.
+
+Improvement Idea:
+Keep the workflow table intact, but append a compact next-step footer that points to workflow inspection first and workspace launch second.
+
+Implementation Hint:
+Update `bin/ai-agent --list-workflows`, document the guidance in `docs/40-cli.md`, and add ordering checks in CLI tests so `ai-agent --describe --workflow <name>` stays ahead of `ai start`.
+
+Expected Impact:
+Users can move from workflow discovery to the right next action without dropping out of the guided beginner path.

--- a/tasks/sprint-memory/issue-83.md
+++ b/tasks/sprint-memory/issue-83.md
@@ -1,0 +1,68 @@
+# Sprint
+
+- issue: `#83`
+- branch: `docs/83-ai-workflows-next-steps`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex + Mendel
+  - Docs / Onboarding specialist: Avicenna
+
+## Compressed Memory
+
+- goal: make `ai workflows` a clearer bridge between workflow discovery and workspace launch
+- decisions:
+  - keep the existing workflow table and source path intact
+  - append a compact `Next Steps` footer instead of redesigning the command
+  - point to `ai-agent --describe --workflow <name>` before `ai start`
+  - keep `ai doctor` as the diagnostic surface and avoid remediation logic here
+- constraints:
+  - stay within one turn-scoped sprint
+  - keep the output short and terminal-friendly
+  - preserve power-user discovery instead of hiding deeper inspection
+- current state: `ai workflows` now ends with beginner-first next-step guidance, docs match the new bridge behavior, and tests cover the footer wording and order
+- next likely moves: inspect whether README or quickstart need a follow-up mention if users still miss the workflow-inspection step
+- open questions: whether `ai workflows` should eventually surface a shorter alias for `ai-agent --describe --workflow <name>`
+
+## Lane Notes
+
+- Product / Backlog: turned the next remaining beginner-path gap into Task 32 and issue `#83`
+- Delivery / Scrum: kept the sprint to one CLI surface plus one docs line and tests
+- Implementer: updating `bin/ai-agent`, `docs/40-cli.md`, `test/ai_cli.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: parallel review pointed to `ai workflows` as the highest-leverage remaining guided-flow gap
+
+## Retrospective Output
+
+- keep
+  - closing guided beginner-path gaps in the order users actually hit them
+- change
+  - treat `ai workflows` as a bridge surface, not just metadata output
+- stop
+  - assuming a raw catalog is enough once a command becomes part of the canonical path
+- follow-ups
+  - inspect whether README or quickstart should mention the new `ai workflows` footer explicitly after the CLI contract lands
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-agent`
+  - `docs/40-cli.md`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - if `ai workflows` output becomes longer later, the footer ordering tests should still keep inspection ahead of `ai start`

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -267,6 +267,15 @@ workflows_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/
 [[ "$workflows_output" == *"workflow | candidates | description"* ]] || fail "ai workflows did not print the metadata header"
 [[ "$workflows_output" == *"code | implementer -> codex -> gemini | Launch the primary implementation agent"* ]] || fail "ai workflows did not list code candidate metadata"
 [[ "$workflows_output" == *"improve | researcher -> codex -> claude | Explore new tools, prompts, and workflow improvements"* ]] || fail "ai workflows did not list improve candidate metadata"
+[[ "$workflows_output" == *"Next Steps:"* ]] || fail "ai workflows did not print next-step guidance"
+[[ "$workflows_output" == *"inspect a workflow: ai-agent --describe --workflow <name>"* ]] || fail "ai workflows did not explain workflow inspection"
+[[ "$workflows_output" == *"then continue the beginner path: ai start"* ]] || fail "ai workflows did not point back to ai start"
+workflows_source_line="$(printf '%s\n' "$workflows_output" | rg '^source:' -n)"
+workflows_inspect_line="$(printf '%s\n' "$workflows_output" | rg '^  - inspect a workflow:' -n)"
+workflows_start_line="$(printf '%s\n' "$workflows_output" | rg '^  - then continue the beginner path:' -n)"
+[[ -n "$workflows_source_line" && -n "$workflows_inspect_line" && -n "$workflows_start_line" ]] || fail "ai workflows did not print ordered next-step guidance"
+[[ "${workflows_source_line%%:*}" -lt "${workflows_inspect_line%%:*}" ]] || fail "ai workflows did not print next-step guidance after the table"
+[[ "${workflows_inspect_line%%:*}" -lt "${workflows_start_line%%:*}" ]] || fail "ai workflows did not keep inspection before ai start"
 
 agent_help_output="$(PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-agent" --help)"
 [[ "$agent_help_output" == *"--describe --workflow review"* ]] || fail "ai-agent help did not include workflow describe usage"
@@ -418,6 +427,7 @@ hosted_failure="$(
 local_workflows_output="$(cd "$TEST_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" workflows)"
 [[ "$local_workflows_output" == *"native | local_reviewer | Local project workflow override"* ]] || fail "local workflows override did not load"
 [[ "$local_workflows_output" == *"source: $TEST_REPO/.ai-dev-os/workflows.yml"* ]] || fail "local workflows output did not report the override source"
+[[ "$local_workflows_output" == *"inspect a workflow: ai-agent --describe --workflow <name>"* ]] || fail "local workflows output did not keep next-step guidance"
 
 local_describe_output="$(cd "$TEST_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-agent" --describe local_reviewer)"
 [[ "$local_describe_output" == *"command: gemini"* ]] || fail "local agent override did not describe gemini"

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -288,6 +288,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not preserve deeper-use guidance after first steps"
   grep -Fq "unknown command に当たった時も" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document unknown-command recovery guidance"
+  grep -Fq "一覧を見たあとは、必要なら \`ai-agent --describe --workflow <name>\`" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document ai workflows next-step guidance"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document healthy ai doctor next steps"
   grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- add a compact `Next Steps` footer to `ai workflows`
- point users to `ai-agent --describe --workflow <name>` before `ai start`
- align CLI docs and guard the new ordering in tests

## Sprint Context
- Issue: Closes #83
- Sprint memory: `tasks/sprint-memory/issue-83.md`
- Review / Demo: `ai workflows` now ends with workflow inspection first and workspace launch second
- System updates: backlog / plans / docs / tests updated

## Verification
- `bash test/ai_cli.sh`
- `bash test/repository_structure.sh`
- `make lint`
- `make test`

## Risk
- low: changes are limited to CLI output guidance, docs wording, and regression guards
