### PR TITLE
docs: define terminal orchestration modes

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #83 `docs: add beginner-first next-step guidance to ai workflows`
-- Branch: `docs/83-ai-workflows-next-steps`
-- Memory Artifact: `tasks/sprint-memory/issue-83.md`
-- Resume Point: `ai workflows` next-step guidance landed; start the next sprint from a fresh issue-backed branch
+- Active issue: #85 `adr: define terminal orchestration modes beyond tmux`
+- Branch: `docs/85-terminal-orchestration-modes`
+- Memory Artifact: `tasks/sprint-memory/issue-85.md`
+- Resume Point: terminal-orchestration boundary is fixed; next sprint can implement the workspace backend adapter from a fresh issue-backed branch
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Make `ai workflows` act like a real beginner-path bridge instead of a flat metadata dump.
+Decide the durable boundary between AI Dev OS as an agent control plane and tmux as the current workspace backend.
 
 ## Working Agreement
 
@@ -33,19 +33,20 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - beginner-first next-step guidance for `ai workflows`
+  - terminal-orchestration boundary ADR and supporting docs
   - concrete surfaces
-  - [`bin/ai-agent`](./bin/ai-agent)
-  - [`docs/40-cli.md`](./docs/40-cli.md)
+  - [`docs/adr/0006-terminal-orchestration-modes.md`](./docs/adr/0006-terminal-orchestration-modes.md)
+  - [`docs/90-philosophy.md`](./docs/90-philosophy.md)
+  - [`docs/91-state-ownership.md`](./docs/91-state-ownership.md)
+  - [`docs/31-support-matrix.md`](./docs/31-support-matrix.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - `ai workflows` ends with a compact next-step footer
-  - the footer points to `ai-agent --describe --workflow <name>` before `ai start`
-  - tests lock the footer wording and order
-  - docs explain the new guidance without blurring `ai doctor` and `ai workflows`
+  - ADR defines AI control plane, workspace backend, and terminal-native integration boundaries
+  - docs state that tmux is currently required for `ai start`, but is not the north-star product boundary
+  - follow-up implementation work is captured in backlog
+  - structure tests guard the new ADR and key wording
 
 ## Squad
 
@@ -59,17 +60,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#83` is the sprint slice for this turn
+  - issue `#85` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 32 was added and converted into issue `#83`
+  - Task 33 was added and converted into issue `#85`; Task 34 is the implementation follow-up
 - Review / Demo
-  - show the `ai workflows` footer order: inspect one workflow, then continue with `ai start`
+  - show the new boundary: AI surface first, tmux as current backend, terminal-native frontends as optional integrations
 - Retrospective
-  - keep discovery surfaces short and ordered
+  - keep architecture decisions ahead of expensive backend rewrites
 
 ## Verification
 
-- `bash test/ai_cli.sh`
 - `bash test/repository_structure.sh`
 - `make lint`
 - `make test`
@@ -77,26 +77,26 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - update [`bin/ai-agent`](./bin/ai-agent) so `ai workflows` ends with compact next-step guidance
-  - keep workflow inspection ahead of workspace launch in both CLI output and docs
-  - lock the footer wording and order in [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - add an ADR that defines tmux as the current workspace backend rather than the AI Dev OS control plane
+  - align philosophy, ownership, and support docs with that boundary
+  - leave a follow-up backlog task for a future workspace backend adapter
 - Retrospective
-  - keep: close beginner-path gaps in the order users actually hit the surfaces
-  - change: add a small next-step contract once a discovery command becomes part of the canonical path
-  - stop: treating `ai workflows` like a raw metadata dump after it became a guided beginner-step
+  - keep: decide long-term boundaries before replacing host-runtime machinery
+  - change: separate durable control-plane decisions from current backend defaults
+  - stop: letting the current tmux implementation silently define the product boundary
 - System Updates
   - backlog: updated
   - plans: updated
   - docs: updated
   - tests: updated
   - instructions: not needed
-  - ADR: not needed
+  - ADR: updated
 
 ## Retrospective
 
 - keep
-  - treating workflow discovery surfaces as part of the guided beginner path
+  - treating host-runtime design as a first-class product decision
 - change
-  - align the middle of the beginner path after the top-level entry surfaces are consistent
+  - decide backend boundaries explicitly before chasing terminal trends
 - stop
-  - leaving `ai workflows` as a raw catalog when the repo now treats it as a core next step
+  - treating tmux as part of the north-star product definition just because it is the current implementation

--- a/docs/31-support-matrix.md
+++ b/docs/31-support-matrix.md
@@ -5,7 +5,7 @@
 - OS: **macOS**
 - パッケージ管理: **Homebrew**
 - shell: **zsh**
-- multiplexer: **tmux**
+- multiplexer: **tmux** (`ai start` の current backend)
 
 ## best-effort / 将来対応の余地
 
@@ -25,7 +25,7 @@
 - bash
 - zsh
 - git
-- tmux
+- tmux (`ai start` は today これを要求する)
 
 ## Linux / WSL で今使えるもの
 

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -54,6 +54,7 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 `ai agents` は `agent | provider | role | command | description` を表示する。
 `ai task` は pending backlog task の短い summary を先に出し、その後に full backlog を表示する。backlog refinement や次 sprint 候補の確認を始める時の入口として使う。
 `ai start` の起動後は、まず `ai doctor` と `ai workflows` を見れば beginner path に戻りやすい。
+`ai start` の workspace launch は today は tmux-backed session を使うが、その backend は current implementation であり AI Dev OS control plane そのものではない。
 project-local scaffold を作りたい時は `ai init` を使う。
 `ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start`、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`、fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。

--- a/docs/90-philosophy.md
+++ b/docs/90-philosophy.md
@@ -3,12 +3,14 @@
 AI Dev OS は、初心者にはわかりやすく、手慣れた人には深く速く使い込めて、1年後も日常的に使い続けられる OS レベルの AI workspace platform を目指す。
 
 shell / tmux / git / bootstrap は重要だが、あくまで AI workflow を支える host substrate として扱う。
+tmux は current workspace backend として重要だが、AI Dev OS の本体そのものではない。
 
 ## 1) 迷ったら AI workflow の入口に戻れる
 
 - beginner の primary entrypoint は `ai start`
 - starter repo では `ai init -> ai doctor -> ai workflows -> ai start` を最短導線にする
 - tmux helper や bootstrap 手順は必要な時だけ見せる
+- `ai start` は today は tmux-backed だが、その backend choice を north-star にしない
 
 ## 2) host substrate は薄く、でも逃げ道は消さない
 
@@ -27,6 +29,7 @@ shell / tmux / git / bootstrap は重要だが、あくまで AI workflow を支
 - shell / tmux / git / clipboard / open helper は日常作業の基盤として扱う
 - ただし user-facing surface は AI workflow の入口を優先し、内部実装を前に出しすぎない
 - 慣れた利用者が標準ツールにそのまま降りられる構成を保つ
+- Ghostty や WezTerm のような terminal-native surface は frontend integration として歓迎するが、control plane と混ぜない
 
 ## 5) 壊れにくさを runtime と host の両方で優先する
 

--- a/docs/91-state-ownership.md
+++ b/docs/91-state-ownership.md
@@ -42,6 +42,9 @@
 - `docs/41-ai-trust.md`
 - `docs/42-github-actions.md`
 
+AI Dev OS control plane は「どの agent / workflow / trust / context を使うか」を管理する。
+workspace をどの backend で開くかは別レイヤーとし、tmux は current backend だが control plane 自体ではない。
+
 ## Ansible が管理するもの
 
 - Homebrew formula / cask 導入
@@ -63,6 +66,10 @@
 - git の一般設定
 - helper command
 - host bootstrap docs / tests
+- current workspace backend 実装
+
+terminal-native integration はここからさらに外側の frontend lane として扱う。
+Ghostty, WezTerm, iTerm2 のような terminal UI / automation は control plane の source of truth にはしない。
 
 ## plugin manager / 外部ツールに依存するもの
 

--- a/docs/adr/0006-terminal-orchestration-modes.md
+++ b/docs/adr/0006-terminal-orchestration-modes.md
@@ -1,0 +1,59 @@
+# 0006 Terminal Orchestration Modes
+
+- Status: Accepted
+- Date: 2026-03-11
+
+## Context
+
+AI Dev OS の primary value は AI workflow routing, vendor-native config との接続, context build, trust boundary, starter onboarding にある。
+
+一方で、現在の `ai start` は tmux に強く依存している。
+そのため実装上の backend が、そのまま product boundary に見えやすい。
+
+この構造には 2 つの緊張がある。
+
+- tmux は detach / attach, session persistence, scriptability の面で今でも強い
+- しかし Ghostty や WezTerm のような terminal-native surface は、UI や OS integration の面で魅力がある
+
+この repo が durable な AI workspace platform を目指すなら、「AI control plane」と「workspace backend」と「terminal-native frontend integration」を分けて考える必要がある。
+
+## Decision
+
+この repo では、AI Dev OS の control plane と workspace execution surface を分離して扱う。
+
+- AI Dev OS control plane
+  - `ai` CLI surface
+  - workflow routing
+  - agent metadata
+  - prompt / context handoff
+  - trust guidance
+  - starter repo onboarding
+- workspace backend
+  - long-lived session を実際に立ち上げる実装
+  - 現時点の current default workspace backend は tmux
+- terminal-native frontend integration
+  - Ghostty, WezTerm, iTerm2 などの terminal UI / automation integration
+  - backend ではなく optional frontend lane として扱う
+
+tmux は current default workspace backend であり、現時点では `ai start` の実行要件でもある。
+しかし tmux 自体を AI Dev OS の north-star product boundary にはしない。
+
+今後の設計原則は次のとおり。
+
+- `ai start` の contract は「AI workspace を開くこと」であって、「tmux を直接 expose すること」ではない
+- tmux helper (`tnew`, `tgo`, `tkill`) は host substrate として残してよい
+- Ghostty や WezTerm は tmux の即時置き換え対象ではなく、terminal-native frontend integration として評価する
+- backend を増やす時は `ai start` の backend adapter を通して増やし、control plane の responsibility は変えない
+- beginner path は 1 本に保ち、backend choice を newcomer-facing default decision にしない
+
+## Consequences
+
+- 短期:
+  - `ai start` は引き続き tmux-backed workspace launcher として維持する
+  - docs では「tmux は current implementation requirement」と「AI surface の本体ではない」を明示する
+- 中期:
+  - `ai start` に workspace backend adapter を導入し、`tmux` を default backend としつつ別 mode を足せるようにする
+  - 最初の alternative backend は `stdio` または terminal-native integration のどちらかで検証する
+- 長期:
+  - terminal-native frontends が成熟しても、workflow routing / trust / context / starter onboarding は control plane に残す
+  - その結果、Ghostty や WezTerm を試しても repo の本質的な product surface はぶれない

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -547,3 +547,37 @@ Update `bin/ai-agent --list-workflows`, document the guidance in `docs/40-cli.md
 
 Expected Impact:
 Users can move from workflow discovery to the right next action without dropping out of the guided beginner path.
+
+## Task 33
+
+Title: Define terminal orchestration modes beyond tmux
+Tracking: #85 (closed)
+
+Problem:
+`ai start` is the primary beginner entrypoint, but its implementation is tightly coupled to tmux. That makes the current backend look like part of the product identity even though the higher-value AI surface lives in workflow routing, vendor-native config, context, trust, and starter onboarding.
+
+Improvement Idea:
+Write down a durable boundary where tmux remains the current workspace backend, but not the long-term control plane or mandatory north-star surface.
+
+Implementation Hint:
+Capture the decision in an ADR, reflect it in philosophy/ownership/support docs, and leave a follow-up implementation task for a workspace backend adapter.
+
+Expected Impact:
+The repo can keep tmux where it is strong today without locking the future product shape to a single terminal backend.
+
+## Task 34
+
+Title: Add a workspace backend adapter for `ai start`
+Tracking: pending
+
+Problem:
+Even if tmux is only the current backend by design, `ai start` still hardcodes tmux as the only workspace execution path. That prevents the product from offering terminal-native or non-attached modes later.
+
+Improvement Idea:
+Introduce a small workspace backend adapter so `ai start` can target `tmux` first while leaving room for `stdio` or terminal-native frontends later.
+
+Implementation Hint:
+Keep `tmux` as the default backend initially, define a narrow backend contract, and add a first alternative mode that can prove the abstraction without changing the newcomer path by default.
+
+Expected Impact:
+AI Dev OS can evolve its workspace launch surface without rewriting the control plane every time a better terminal integration appears.

--- a/tasks/sprint-memory/issue-85.md
+++ b/tasks/sprint-memory/issue-85.md
@@ -1,0 +1,68 @@
+# Sprint
+
+- issue: `#85`
+- branch: `docs/85-terminal-orchestration-modes`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+  - Architecture lane: external official docs + local repo audit
+
+## Compressed Memory
+
+- goal: decide whether tmux is part of the long-term AI Dev OS product boundary or only the current workspace backend
+- decisions:
+  - keep tmux as the current default backend for `ai start`
+  - do not treat tmux as the AI Dev OS control plane or north-star surface
+  - classify Ghostty / WezTerm / similar tools as terminal-native frontend integrations, not the system core
+  - require a future workspace backend adapter before adding alternative launch modes
+- constraints:
+  - do not claim tmux is optional today for `ai start`
+  - keep the beginner path stable while redefining the architecture boundary
+  - keep follow-up implementation work out of this ADR sprint
+- current state: ADR and supporting docs now define tmux as the current backend rather than the AI Dev OS core; follow-up implementation work is captured as Task 34
+- next likely moves: add the follow-up implementation task for a backend adapter, then decide whether the first alternative mode should be `stdio` or a terminal-native integration
+- open questions: whether the first post-tmux experiment should optimize for persistence (`tmux` parity) or for terminal-native UX
+
+## Lane Notes
+
+- Product / Backlog: converted the user concern into a decision issue plus a concrete implementation follow-up
+- Delivery / Scrum: kept the sprint to architecture and documentation, not a backend rewrite
+- Implementer: updating ADR, philosophy, ownership, support docs, and repo guards
+- Architecture lane: local audit showed tmux is currently mandatory in `bin/ai-start`; official docs suggest Ghostty is attractive as a frontend but not a durable session backend
+
+## Retrospective Output
+
+- keep
+  - forcing a clean architecture decision before swapping execution backends
+- change
+  - make current implementation requirements explicit without elevating them into the product north star
+- stop
+  - letting backend choice leak into the control-plane identity
+- follow-ups
+  - implement a workspace backend adapter in a separate issue
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: updated
+
+## Handoff
+
+- read first:
+  - `bin/ai-start`
+  - `docs/90-philosophy.md`
+  - `docs/91-state-ownership.md`
+  - `docs/adr/0006-terminal-orchestration-modes.md`
+- rerun commands:
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - docs must stay precise that tmux is still required today for `ai start`, otherwise the architecture decision will read like an implementation claim

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -229,6 +229,7 @@ verify_layout_scaffold() {
   assert_file "$REPO/docs/adr/0003-ai-dev-os-scrum-cadence.md"
   assert_file "$REPO/docs/adr/0004-ai-dev-os-retro-memory-loop.md"
   assert_file "$REPO/docs/adr/0005-turn-scoped-sprint-cadence.md"
+  assert_file "$REPO/docs/adr/0006-terminal-orchestration-modes.md"
   assert_file "$REPO/docs/05-demo-walkthrough.md"
   assert_file "$REPO/docs/41-ai-trust.md"
   assert_file "$REPO/docs/42-github-actions.md"
@@ -290,6 +291,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not document unknown-command recovery guidance"
   grep -Fq "一覧を見たあとは、必要なら \`ai-agent --describe --workflow <name>\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document ai workflows next-step guidance"
+  grep -Fq "workspace launch は today は tmux-backed session を使う" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document the current tmux-backed ai-start implementation"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document healthy ai doctor next steps"
   grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \
@@ -422,8 +425,12 @@ verify_ai_dev_os_docs() {
     || fail "templates/plans/PLANS.md does not cover multi-turn sprints"
   grep -Fq "AI Dev OS" "$REPO/docs/90-philosophy.md" \
     || fail "docs/90-philosophy.md does not use the AI Dev OS framing"
+  grep -Fq "tmux は current workspace backend" "$REPO/docs/90-philosophy.md" \
+    || fail "docs/90-philosophy.md does not distinguish tmux backend from the AI Dev OS core"
   grep -Fq "AI Dev OS control plane" "$REPO/docs/91-state-ownership.md" \
     || fail "docs/91-state-ownership.md does not describe the AI Dev OS control plane boundary"
+  grep -Fq "workspace をどの backend で開くかは別レイヤー" "$REPO/docs/91-state-ownership.md" \
+    || fail "docs/91-state-ownership.md does not separate workspace backend from the AI control plane"
   grep -Fq "AI_DEV_OS_EDITOR" "$REPO/docs/61-local-customization.md" \
     || fail "docs/61-local-customization.md does not recommend AI Dev OS editor aliases"
   grep -Fq "primary product surface" "$REPO/docs/adr/0002-ai-dev-os-primary-surface.md" \
@@ -436,6 +443,10 @@ verify_ai_dev_os_docs() {
     || fail "docs/adr/0004-ai-dev-os-retro-memory-loop.md does not record the compressed sprint memory decision"
   grep -Fq "one user/assistant round-trip as one sprint" "$REPO/docs/adr/0005-turn-scoped-sprint-cadence.md" \
     || fail "docs/adr/0005-turn-scoped-sprint-cadence.md does not record the turn-scoped sprint decision"
+  grep -Fq "current default workspace backend" "$REPO/docs/adr/0006-terminal-orchestration-modes.md" \
+    || fail "docs/adr/0006-terminal-orchestration-modes.md does not define tmux as the current backend"
+  grep -Fq "terminal-native frontend integration" "$REPO/docs/adr/0006-terminal-orchestration-modes.md" \
+    || fail "docs/adr/0006-terminal-orchestration-modes.md does not define terminal-native integrations"
   grep -Fq "Compressed Memory" "$REPO/tasks/sprint-memory/README.md" \
     || fail "tasks/sprint-memory/README.md does not define compressed memory"
   grep -Fq "System Updates" "$REPO/tasks/sprint-memory/README.md" \
@@ -489,6 +500,8 @@ verify_doctor_guidance_consistency() {
     || fail "docs/00-quickstart.md does not keep the canonical make doctor guidance"
   grep -Fq "workflow / prompt / trust / fallback / runtime config を見る時は \`make doctor\` ではなく \`ai doctor\`" "$REPO/docs/31-support-matrix.md" \
     || fail "docs/31-support-matrix.md does not keep the canonical ai doctor guidance"
+  grep -Fq "multiplexer: **tmux** (\`ai start\` の current backend)" "$REPO/docs/31-support-matrix.md" \
+    || fail "docs/31-support-matrix.md does not describe tmux as the current ai-start backend"
   grep -Fq "workflow / prompt / trust / fallback / runtime config を診断する" "$REPO/docs/99-troubleshooting.md" \
     || fail "docs/99-troubleshooting.md does not keep the canonical ai doctor guidance"
   grep -Fq "host bootstrap / symlink / PATH / shell / system state を見る" "$REPO/docs/99-troubleshooting.md" \


### PR DESCRIPTION
## Summary
- add an ADR that separates the AI control plane from the current tmux workspace backend
- align philosophy, ownership, support, and CLI docs with that boundary
- capture a follow-up backlog task for a future `ai start` workspace backend adapter

## Sprint Context
- Issue: Closes #85
- Sprint memory: `tasks/sprint-memory/issue-85.md`
- Review / Demo: tmux is now documented as the current `ai start` backend, not the AI Dev OS north-star boundary
- System updates: backlog / plans / docs / tests / ADR updated

## Verification
- `bash test/repository_structure.sh`
- `make lint`
- `make test`

## Risk
- low: this sprint changes architecture/docs/contracts only; it does not alter current tmux-backed runtime behavior
