### PR TITLE
feat: add ai-start backend adapter

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #85 `adr: define terminal orchestration modes beyond tmux`
-- Branch: `docs/85-terminal-orchestration-modes`
-- Memory Artifact: `tasks/sprint-memory/issue-85.md`
-- Resume Point: terminal-orchestration boundary is fixed; next sprint can implement the workspace backend adapter from a fresh issue-backed branch
+- Active issue: #87 `feat: add a workspace backend adapter to ai start`
+- Branch: `feat/87-ai-start-backend-adapter`
+- Memory Artifact: `tasks/sprint-memory/issue-87.md`
+- Resume Point: ai-start backend adapter landed; next sprint can explore richer backends from a fresh issue-backed branch
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Decide the durable boundary between AI Dev OS as an agent control plane and tmux as the current workspace backend.
+Implement the first workspace backend adapter so `ai start` keeps tmux as default without fixing terminal choice forever.
 
 ## Working Agreement
 
@@ -33,20 +33,21 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - terminal-orchestration boundary ADR and supporting docs
+  - `ai start` workspace backend adapter
   - concrete surfaces
-  - [`docs/adr/0006-terminal-orchestration-modes.md`](./docs/adr/0006-terminal-orchestration-modes.md)
-  - [`docs/90-philosophy.md`](./docs/90-philosophy.md)
-  - [`docs/91-state-ownership.md`](./docs/91-state-ownership.md)
+  - [`bin/ai-start`](./bin/ai-start)
   - [`docs/31-support-matrix.md`](./docs/31-support-matrix.md)
+  - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
+  - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - ADR defines AI control plane, workspace backend, and terminal-native integration boundaries
-  - docs state that tmux is currently required for `ai start`, but is not the north-star product boundary
-  - follow-up implementation work is captured in backlog
-  - structure tests guard the new ADR and key wording
+  - `ai start` supports backend selection
+  - default behavior remains tmux-backed
+  - `stdio` backend works without tmux
+  - docs explain backend selection and current default
+  - tests cover backend selection and the non-tmux path
 
 ## Squad
 
@@ -60,13 +61,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#85` is the sprint slice for this turn
+  - issue `#87` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 33 was added and converted into issue `#85`; Task 34 is the implementation follow-up
+  - Task 34 was converted into issue `#87`
 - Review / Demo
-  - show the new boundary: AI surface first, tmux as current backend, terminal-native frontends as optional integrations
+  - show tmux as default backend and stdio as a non-tmux alternative
 - Retrospective
-  - keep architecture decisions ahead of expensive backend rewrites
+  - keep backend abstraction narrower than terminal strategy
 
 ## Verification
 
@@ -77,26 +78,26 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - add an ADR that defines tmux as the current workspace backend rather than the AI Dev OS control plane
-  - align philosophy, ownership, and support docs with that boundary
-  - leave a follow-up backlog task for a future workspace backend adapter
+  - update [`bin/ai-start`](./bin/ai-start) to support backend selection with tmux as default and stdio as the first alternative
+  - align [`docs/40-cli.md`](./docs/40-cli.md) and [`docs/31-support-matrix.md`](./docs/31-support-matrix.md) with the new backend contract
+  - lock the non-tmux path in [`test/ai_cli.sh`](./test/ai_cli.sh)
 - Retrospective
-  - keep: decide long-term boundaries before replacing host-runtime machinery
-  - change: separate durable control-plane decisions from current backend defaults
-  - stop: letting the current tmux implementation silently define the product boundary
+  - keep: prove the abstraction with one small alternative backend before considering terminal-native integrations
+  - change: encode backend defaults and alternatives in output/docs/tests together
+  - stop: treating tmux-only implementation as enough once the boundary is already explicit
 - System Updates
   - backlog: updated
   - plans: updated
   - docs: updated
   - tests: updated
   - instructions: not needed
-  - ADR: updated
+  - ADR: not needed
 
 ## Retrospective
 
 - keep
-  - treating host-runtime design as a first-class product decision
+  - keeping implementation aligned with the already-decided architecture boundary
 - change
-  - decide backend boundaries explicitly before chasing terminal trends
+  - prove backend flexibility with a small non-tmux mode first
 - stop
-  - treating tmux as part of the north-star product definition just because it is the current implementation
+  - leaving terminal choice fixed in practice after deciding it should stay flexible

--- a/bin/ai-start
+++ b/bin/ai-start
@@ -17,7 +17,7 @@ source "$TMUX_LAYOUT"
 
 usage() {
   cat <<'EOF'
-usage: ai-start [--repo PATH] [--stop]
+usage: ai-start [--repo PATH] [--backend <tmux|stdio>] [--stop]
 EOF
 }
 
@@ -46,12 +46,18 @@ require_command() {
 
 repo_path=""
 stop_requested=0
+backend_name="${AI_WORKSPACE_BACKEND:-tmux}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
       [[ $# -ge 2 ]] || { usage >&2; exit 2; }
       repo_path="$2"
+      shift 2
+      ;;
+    --backend)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      backend_name="$2"
       shift 2
       ;;
     --stop)
@@ -69,39 +75,64 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "$backend_name" in
+  tmux|stdio)
+    ;;
+  *)
+    echo "unknown workspace backend: $backend_name" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
 target_repo="$(ai_target_repo_root "${repo_path:-$PWD}")"
 window_name="${AI_TMUX_WINDOW_NAME:-workspace}"
 [[ -n "$window_name" ]] || window_name="workspace"
 session_name="$(ai_session_name "$target_repo" "$TMUX_LAYOUT")"
 context_command="$REPO_ROOT/bin/ai-context --repo $target_repo --show"
 
-require_command tmux "$(platform_remediation)"
+if [[ $stop_requested -eq 1 ]]; then
+  case "$backend_name" in
+    tmux)
+      require_command tmux "$(platform_remediation)"
+      if tmux has-session -t "$session_name" >/dev/null 2>&1; then
+        tmux kill-session -t "$session_name"
+      fi
+      ;;
+    stdio)
+      ;;
+  esac
+  exit 0
+fi
 
 if ! "$REPO_ROOT/bin/ai-context" --repo "$target_repo" >/dev/null; then
   echo "failed to build repository context for $target_repo" >&2
   exit 1
 fi
 
-if [[ $stop_requested -eq 1 ]]; then
-  if tmux has-session -t "$session_name" >/dev/null 2>&1; then
-    tmux kill-session -t "$session_name"
-  fi
-  exit 0
-fi
+case "$backend_name" in
+  tmux)
+    require_command tmux "$(platform_remediation)"
+    if ! tmux has-session -t "$session_name" >/dev/null 2>&1; then
+      tmux new-session -d -s "$session_name" -n "$window_name" -c "$target_repo"
+      tmux split-window -v -t "$session_name:$window_name.1" -c "$target_repo"
+      tmux send-keys -t "$session_name:$window_name.2" "$context_command" C-m
+      tmux select-layout -t "$session_name:$window_name" "${AI_TMUX_LAYOUT_PRESET:-tiled}"
+      tmux select-pane -t "$session_name:$window_name.1"
+    fi
+    workspace_label="$session_name"
+    ;;
+  stdio)
+    workspace_label="stdio"
+    ;;
+esac
 
-if ! tmux has-session -t "$session_name" >/dev/null 2>&1; then
-  tmux new-session -d -s "$session_name" -n "$window_name" -c "$target_repo"
-  tmux split-window -v -t "$session_name:$window_name.1" -c "$target_repo"
-  tmux send-keys -t "$session_name:$window_name.2" "$context_command" C-m
-  tmux select-layout -t "$session_name:$window_name" "${AI_TMUX_LAYOUT_PRESET:-tiled}"
-  tmux select-pane -t "$session_name:$window_name.1"
-fi
-
-printf 'AI Dev OS workspace ready: %s\n' "$session_name"
+printf 'AI Dev OS workspace ready: %s\n' "$workspace_label"
 printf 'Workspace: %s\n' "$target_repo"
+printf 'Backend: %s\n' "$backend_name"
 printf 'Next: ai doctor | ai workflows\n'
 printf 'Then: ai code | ai review | ai task | ai agents\n'
 
-if [[ -t 1 && -z "${TMUX:-}" ]]; then
+if [[ "$backend_name" == "tmux" && -t 1 && -z "${TMUX:-}" ]]; then
   exec tmux attach-session -t "$session_name"
 fi

--- a/docs/31-support-matrix.md
+++ b/docs/31-support-matrix.md
@@ -5,7 +5,7 @@
 - OS: **macOS**
 - パッケージ管理: **Homebrew**
 - shell: **zsh**
-- multiplexer: **tmux** (`ai start` の current backend)
+- multiplexer: **tmux** (`ai start` の current default backend)
 
 ## best-effort / 将来対応の余地
 
@@ -25,7 +25,8 @@
 - bash
 - zsh
 - git
-- tmux (`ai start` は today これを要求する)
+- tmux (`ai start` default backend は today これを要求する)
+- stdio (`ai start --backend stdio` は tmux なしで動く)
 
 ## Linux / WSL で今使えるもの
 

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -54,7 +54,8 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 `ai agents` は `agent | provider | role | command | description` を表示する。
 `ai task` は pending backlog task の短い summary を先に出し、その後に full backlog を表示する。backlog refinement や次 sprint 候補の確認を始める時の入口として使う。
 `ai start` の起動後は、まず `ai doctor` と `ai workflows` を見れば beginner path に戻りやすい。
-`ai start` の workspace launch は today は tmux-backed session を使うが、その backend は current implementation であり AI Dev OS control plane そのものではない。
+`ai start` の workspace launch は today は tmux-backed session を default に使うが、その backend は current implementation であり AI Dev OS control plane そのものではない。
+terminal choice を固定したくない時は `ai start --backend stdio` か `AI_WORKSPACE_BACKEND=stdio ai start` を使える。default は引き続き `tmux`。
 project-local scaffold を作りたい時は `ai init` を使う。
 `ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start`、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`、fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -568,7 +568,7 @@ The repo can keep tmux where it is strong today without locking the future produ
 ## Task 34
 
 Title: Add a workspace backend adapter for `ai start`
-Tracking: pending
+Tracking: #87 (closed)
 
 Problem:
 Even if tmux is only the current backend by design, `ai start` still hardcodes tmux as the only workspace execution path. That prevents the product from offering terminal-native or non-attached modes later.

--- a/tasks/sprint-memory/issue-87.md
+++ b/tasks/sprint-memory/issue-87.md
@@ -1,0 +1,69 @@
+# Sprint
+
+- issue: `#87`
+- branch: `feat/87-ai-start-backend-adapter`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+  - QA specialist: Kepler
+  - Exploration specialist: Hypatia
+
+## Compressed Memory
+
+- goal: add a narrow workspace backend adapter to `ai start` so tmux stays default without remaining the only path
+- decisions:
+  - keep `tmux` as the default backend
+  - add `stdio` as the first alternative backend
+  - support both `--backend stdio` and `AI_WORKSPACE_BACKEND=stdio`
+  - keep the beginner guidance identical across backends
+- constraints:
+  - do not break current tmux-backed behavior
+  - do not introduce terminal-native integrations in this sprint
+  - keep docs explicit that tmux is still the current default
+- current state: `ai start` now supports backend selection, keeps tmux as default, and offers a stdio backend that works without tmux
+- next likely moves: finish verification, then close and merge
+- open questions: whether `stdio` should eventually print a stronger hint for terminal-native follow-up integrations
+
+## Lane Notes
+
+- Product / Backlog: implemented the follow-up promised by ADR 0006
+- Delivery / Scrum: kept the sprint to one backend abstraction and one alternative mode
+- Implementer: updating `bin/ai-start`, CLI docs, support docs, and tests
+- Reviewer / QA: main risk is drift between the default tmux path and the non-tmux contract
+
+## Retrospective Output
+
+- keep
+  - proving architectural flexibility with a small runnable alternative
+- change
+  - test non-default backend paths explicitly once a command gains a backend selector
+- stop
+  - assuming the default backend contract is enough coverage
+- follow-ups
+  - evaluate whether the next backend should be terminal-native or another non-attached mode
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-start`
+  - `docs/40-cli.md`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - default tmux behavior and stdio behavior must stay aligned on the same beginner guidance while keeping different backend requirements

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -352,6 +352,7 @@ printf "copied" | PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-copy"
 start_output="$(PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-start" --repo "$TEST_REPO")"
 [[ -f "$TEST_REPO/.context/summary.md" ]] || fail "ai-start did not refresh summary.md"
 [[ "$start_output" == *"AI Dev OS workspace ready:"* ]] || fail "ai-start did not print the workspace-ready line"
+[[ "$start_output" == *"Backend: tmux"* ]] || fail "ai-start did not report the tmux backend"
 [[ "$start_output" == *"Next: ai doctor | ai workflows"* ]] || fail "ai-start did not print the beginner guidance"
 [[ "$start_output" == *"Then: ai code | ai review | ai task | ai agents"* ]] || fail "ai-start did not keep the deeper commands visible"
 start_next_line="$(printf '%s\n' "$start_output" | rg '^Next:' -n)"
@@ -366,7 +367,15 @@ assert_contains "$TMUX_LOG" "select-layout -t ai-dev-os-project:workspace tiled"
 PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" stop --repo "$TEST_REPO" >/dev/null
 assert_contains "$TMUX_LOG" "kill-session -t ai-dev-os-project"
 
+tmux_log_before_stdio="$(cat "$TMUX_LOG")"
 rm -f "$STUB_BIN/tmux"
+stdio_output="$(PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TEST_REPO" --backend stdio)"
+[[ "$stdio_output" == *"AI Dev OS workspace ready: stdio"* ]] || fail "ai-start stdio backend did not print the stdio workspace label"
+[[ "$stdio_output" == *"Backend: stdio"* ]] || fail "ai-start stdio backend did not report the stdio backend"
+[[ "$stdio_output" == *"Next: ai doctor | ai workflows"* ]] || fail "ai-start stdio backend did not keep the beginner guidance"
+[[ "$(cat "$TMUX_LOG")" == "$tmux_log_before_stdio" ]] || fail "ai-start stdio backend unexpectedly touched tmux"
+PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TEST_REPO" --backend stdio --stop >/dev/null
+
 start_failure="$(
   PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TEST_REPO" 2>&1 >/dev/null || true
 )"

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -291,8 +291,10 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not document unknown-command recovery guidance"
   grep -Fq "一覧を見たあとは、必要なら \`ai-agent --describe --workflow <name>\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document ai workflows next-step guidance"
-  grep -Fq "workspace launch は today は tmux-backed session を使う" "$REPO/docs/40-cli.md" \
+  grep -Fq "workspace launch は today は tmux-backed session を default に使う" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document the current tmux-backed ai-start implementation"
+  grep -Fq "ai start --backend stdio" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document the stdio backend override"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document healthy ai doctor next steps"
   grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \
@@ -500,8 +502,10 @@ verify_doctor_guidance_consistency() {
     || fail "docs/00-quickstart.md does not keep the canonical make doctor guidance"
   grep -Fq "workflow / prompt / trust / fallback / runtime config を見る時は \`make doctor\` ではなく \`ai doctor\`" "$REPO/docs/31-support-matrix.md" \
     || fail "docs/31-support-matrix.md does not keep the canonical ai doctor guidance"
-  grep -Fq "multiplexer: **tmux** (\`ai start\` の current backend)" "$REPO/docs/31-support-matrix.md" \
+  grep -Fq "multiplexer: **tmux** (\`ai start\` の current default backend)" "$REPO/docs/31-support-matrix.md" \
     || fail "docs/31-support-matrix.md does not describe tmux as the current ai-start backend"
+  grep -Fq "stdio (\`ai start --backend stdio\` は tmux なしで動く)" "$REPO/docs/31-support-matrix.md" \
+    || fail "docs/31-support-matrix.md does not document the stdio backend"
   grep -Fq "workflow / prompt / trust / fallback / runtime config を診断する" "$REPO/docs/99-troubleshooting.md" \
     || fail "docs/99-troubleshooting.md does not keep the canonical ai doctor guidance"
   grep -Fq "host bootstrap / symlink / PATH / shell / system state を見る" "$REPO/docs/99-troubleshooting.md" \


### PR DESCRIPTION
## Summary
- add workspace backend selection to `ai start`
- keep `tmux` as the default backend and add a first `stdio` alternative
- align CLI/support docs and tests with the new backend contract

## Sprint Context
- Issue: Closes #87
- Sprint memory: `tasks/sprint-memory/issue-87.md`
- Review / Demo: `ai start` now keeps tmux as default while allowing `--backend stdio` or `AI_WORKSPACE_BACKEND=stdio`
- System updates: backlog / plans / docs / tests updated

## Verification
- `bash test/ai_cli.sh`
- `bash test/repository_structure.sh`
- `make lint`
- `make test`

## Risk
- low: default tmux behavior is preserved; the new path is additive and covered by CLI regression tests
