### PR TITLE
docs: align ai-init backend guidance

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #89 `docs: align newcomer docs with ai-start backend options`
-- Branch: `docs/89-ai-start-backend-docs`
-- Memory Artifact: `tasks/sprint-memory/issue-89.md`
-- Resume Point: newcomer docs now reflect tmux default plus stdio alternative; next sprint can move to generated starter or richer backend surfaces
+- Active issue: #91 `docs: align ai-init starter guidance with ai-start backend options`
+- Branch: `docs/91-ai-init-backend-guidance`
+- Memory Artifact: `tasks/sprint-memory/issue-91.md`
+- Resume Point: generated starter guidance now reflects tmux default plus stdio alternative; next sprint can move to backend-aware doctor or richer starter surfaces
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align newcomer-facing docs with the current `ai start` backend contract so terminal choice stays flexible in practice as well as in code.
+Align generated starter guidance with the current `ai start` backend contract so first-run artifacts tell the same story as the runtime docs.
 
 ## Working Agreement
 
@@ -33,20 +33,19 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - newcomer/docs alignment for `ai start` backends
+  - backend-aware `ai init` starter guidance
   - concrete surfaces
-  - [`README.md`](./README.md)
-  - [`docs/00-quickstart.md`](./docs/00-quickstart.md)
-  - [`docs/05-demo-walkthrough.md`](./docs/05-demo-walkthrough.md)
-  - [`docs/99-troubleshooting.md`](./docs/99-troubleshooting.md)
+  - [`bin/ai-init`](./bin/ai-init)
+  - [`demo/sample-project/.ai-dev-os/README.md`](./demo/sample-project/.ai-dev-os/README.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
+  - [`test/ai_init.sh`](./test/ai_init.sh)
   - [`test/demo_assets.sh`](./test/demo_assets.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - high-traffic newcomer docs mention `tmux` as the current default and `stdio` as an alternative
-  - troubleshooting points to `stdio` as a valid escape hatch when only the tmux default path is blocked
-  - demo walkthrough stays aligned with the beginner path while exposing the stdio option
+  - generated starter README mentions `tmux` as the current default and `stdio` as an alternative
+  - `ai init` output mentions the backend-aware `ai start` contract
+  - demo starter fixture stays in sync
   - tests guard the new wording
 
 ## Squad
@@ -61,17 +60,18 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#89` is the sprint slice for this turn
+  - issue `#91` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 35 was added and converted into issue `#89`
+  - Task 36 was added and converted into issue `#91`
 - Review / Demo
-  - show tmux as default backend and stdio as the lighter newcomer-facing alternative
+  - show generated starter guidance using tmux default plus stdio alternative
 - Retrospective
-  - keep docs aligned immediately after behavior changes
+  - keep generated surfaces aligned immediately after runtime/docs changes
 
 ## Verification
 
 - `bash test/demo_assets.sh`
+- `bash test/ai_init.sh`
 - `bash test/repository_structure.sh`
 - `make lint`
 - `make test`
@@ -79,13 +79,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - align README, quickstart, demo walkthrough, and troubleshooting with `tmux` default plus `stdio` alternative
-  - keep the newcomer path order unchanged while exposing the non-tmux escape hatch
-  - lock the wording with structure and demo guards
+  - align `ai init` output and generated starter README with `tmux` default plus `stdio` alternative
+  - keep the local-first onboarding order unchanged
+  - lock the wording with init/demo/structure guards
 - Retrospective
-  - keep: update the highest-traffic docs right after changing a core entrypoint contract
-  - change: treat troubleshooting as part of the beginner-path contract, not as an afterthought
-  - stop: leaving newcomer docs on an older backend story after the code moves ahead
+  - keep: follow top-level docs with generated-surface alignment in the next sprint
+  - change: treat `ai init` output as part of the beginner contract, not just scaffolding noise
+  - stop: leaving generated starter artifacts one backend story behind
 - System Updates
   - backlog: updated
   - plans: updated
@@ -97,8 +97,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - keeping high-traffic docs aligned with code-level backend changes
+  - keeping generated starter surfaces aligned with code-level backend changes
 - change
-  - move the docs follow-through into the very next sprint when an entrypoint contract changes
+  - move generated-surface follow-through into the next sprint after top-level docs land
 - stop
-  - assuming CLI docs alone are enough once README and troubleshooting still say less
+  - assuming runtime docs are enough once starter artifacts still say less

--- a/bin/ai-init
+++ b/bin/ai-init
@@ -136,6 +136,8 @@ ai trust init claude --project
 ai start
 ```
 
+`ai start` の current default backend は `tmux`。terminal choice を固定したくない時は `ai start --backend stdio` を使える。
+
 ## Trust Setup
 
 - repo-local starter: `ai trust init claude --project`
@@ -164,6 +166,7 @@ EOF
 
 - local-only first
   - stay on `ai doctor` / `ai workflows` / `ai start`
+  - default backend は `tmux`、lighter path は `ai start --backend stdio`
   - use this when CI is not the current problem
 - PR CI next
   - keep `.github/workflows/ai-dev-os-pr.yml`
@@ -242,6 +245,7 @@ EOF
 - local-only first
   - this run skipped GitHub Actions via `--no-github-actions`
   - stay on `ai doctor` / `ai workflows` / `ai start`
+  - default backend は `tmux`、lighter path は `ai start --backend stdio`
 - PR CI later
   - rerun `ai init` without `--no-github-actions` when pull-request smoke checks become useful
   - use this when you want prompt validation and CLI smoke on pull requests
@@ -374,6 +378,7 @@ printf 'initialized repo: %s\n' "$target_repo"
 printf 'next: ai doctor\n'
 printf 'next: ai workflows\n'
 printf 'next: ai agents\n'
+printf 'note: ai start uses tmux by default; use ai start --backend stdio when terminal choice should stay flexible\n'
 printf 'next: ai trust init claude --project\n'
 printf 'next: ai start\n'
 if [[ $include_github_actions -eq 1 ]]; then

--- a/demo/sample-project/.ai-dev-os/README.md
+++ b/demo/sample-project/.ai-dev-os/README.md
@@ -23,6 +23,8 @@ ai trust init claude --project
 ai start
 ```
 
+`ai start` の current default backend は `tmux`。terminal choice を固定したくない時は `ai start --backend stdio` を使える。
+
 ## Trust Setup
 
 - repo-local starter: `ai trust init claude --project`
@@ -47,6 +49,7 @@ If a workflow cannot launch as expected, run `ai doctor` first to inspect fallba
 
 - local-only first
   - stay on `ai doctor` / `ai workflows` / `ai start`
+  - default backend は `tmux`、lighter path は `ai start --backend stdio`
   - use this when CI is not the current problem
 - PR CI next
   - keep `.github/workflows/ai-dev-os-pr.yml`

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -598,3 +598,20 @@ Update README, quickstart, demo walkthrough, and troubleshooting. Add narrow wor
 
 Expected Impact:
 Users can discover the non-tmux path from the first docs they read, without losing the default tmux story or the beginner path ordering.
+
+## Task 36
+
+Title: Align `ai init` starter guidance with `ai start` backend options
+Tracking: #91 (closed)
+
+Problem:
+`ai start` now supports `tmux` as the default backend and `stdio` as an alternative, but generated starter guidance still treats `ai start` as a single undifferentiated path.
+
+Improvement Idea:
+Update the generated starter README and `ai init` next-step output so they present `tmux` as the current default and `stdio` as the lighter alternative when terminal choice should stay flexible.
+
+Implementation Hint:
+Update `bin/ai-init`, keep the demo starter fixture in sync, and extend `test/ai_init.sh` plus structure/demo guards to lock the wording down.
+
+Expected Impact:
+The first generated artifact a new adopter reads tells the same backend story as the runtime docs and CLI surface.

--- a/tasks/sprint-memory/issue-91.md
+++ b/tasks/sprint-memory/issue-91.md
@@ -1,0 +1,68 @@
+# Sprint
+
+- issue: `#91`
+- branch: `docs/91-ai-init-backend-guidance`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: align generated starter guidance with the current `ai start` backend options
+- decisions:
+  - keep `tmux` as the current default story in generated artifacts
+  - expose `stdio` as the lighter alternative in starter README and init output
+  - avoid changing onboarding order or overloading the starter with advanced terminal detail
+  - keep demo fixture identical to generated output
+- constraints:
+  - stay focused on generated surfaces
+  - do not change ai-start behavior
+  - preserve local-first adoption wording
+- current state: `ai init` output and generated starter README now reflect tmux default plus stdio alternative, and fixture sync confirms the final content
+- next likely moves: run ai-init, demo, and structure tests, then full verification and closeout
+- open questions: whether a later sprint should mention backend-aware `ai start` in generated starter GitHub Actions notes too
+
+## Lane Notes
+
+- Product / Backlog: turned the post-#89 starter gap into Task 36 and issue `#91`
+- Delivery / Scrum: kept the sprint to generated output, fixture sync, and tests
+- Implementer: updating `bin/ai-init`, demo starter README, and init/structure tests
+- Reviewer / QA: main risk is drifting the generated fixture away from actual ai-init output
+
+## Retrospective Output
+
+- keep
+  - treating generated starter artifacts as part of the beginner-facing product surface
+- change
+  - follow top-level docs with scaffold/output alignment immediately after contract changes
+- stop
+  - assuming fixture sync alone is enough without wording assertions in ai-init tests
+- follow-ups
+  - consider backend-aware guidance in more generated starter artifacts if new backends appear
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-init`
+  - `demo/sample-project/.ai-dev-os/README.md`
+  - `test/ai_init.sh`
+- rerun commands:
+  - `bash test/ai_init.sh`
+  - `bash test/demo_assets.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - the generated README and demo fixture must remain byte-for-byte aligned after wording changes

--- a/test/ai_init.sh
+++ b/test/ai_init.sh
@@ -58,13 +58,15 @@ init_output="$(cd "$TARGET_REPO/src" && "$REPO/bin/ai" init)"
 [[ "$init_output" == *"initialized repo: $TARGET_REPO"* ]] || fail "ai init did not report the initialized repo"
 [[ "$init_output" == *"next: ai doctor"* ]] || fail "ai init did not print doctor guidance"
 [[ "$init_output" == *"next: ai workflows"* ]] || fail "ai init did not print next workflow guidance"
+[[ "$init_output" == *"note: ai start uses tmux by default; use ai start --backend stdio when terminal choice should stay flexible"* ]] || fail "ai init did not print backend-aware ai start guidance"
 [[ "$init_output" == *"next: ai trust init claude --project"* ]] || fail "ai init did not print trust guidance"
 [[ "$init_output" == *"next: ai start"* ]] || fail "ai init did not print ai start guidance"
 [[ "$init_output" == *"optional: sed -n '1,160p' .github/workflows/ai-dev-os-pr.yml"* ]] || fail "ai init did not print optional GitHub Actions guidance"
 [[ "$init_output" == *"optional: gh workflow run ai-dev-os-hosted-eval.yml"* ]] || fail "ai init did not print optional hosted eval guidance"
 assert_output_order "$init_output" "next: ai doctor" "next: ai workflows"
 assert_output_order "$init_output" "next: ai workflows" "next: ai agents"
-assert_output_order "$init_output" "next: ai agents" "next: ai start"
+assert_output_order "$init_output" "next: ai agents" "note: ai start uses tmux by default; use ai start --backend stdio when terminal choice should stay flexible"
+assert_output_order "$init_output" "note: ai start uses tmux by default; use ai start --backend stdio when terminal choice should stay flexible" "next: ai start"
 
 assert_file "$TARGET_REPO/.ai-dev-os/agents.yml"
 assert_file "$TARGET_REPO/.ai-dev-os/workflows.yml"
@@ -93,6 +95,8 @@ grep -Fq "ai-agent --describe --workflow review" "$TARGET_REPO/.ai-dev-os/README
   || fail "ai init did not document workflow describe guidance"
 grep -Fq "ai trust init claude --project" "$TARGET_REPO/.ai-dev-os/README.md" \
   || fail "ai init did not document trust init guidance"
+grep -Fq "ai start --backend stdio" "$TARGET_REPO/.ai-dev-os/README.md" \
+  || fail "ai init did not document the stdio ai-start option"
 grep -Fq "## If Something Fails" "$TARGET_REPO/.ai-dev-os/README.md" \
   || fail "ai init did not document the failure model"
 grep -Fq "local onboarding problem" "$TARGET_REPO/.ai-dev-os/README.md" \
@@ -105,6 +109,8 @@ grep -Fq "## Which Path To Choose" "$TARGET_REPO/.ai-dev-os/README.md" \
   || fail "ai init did not document the adoption guide"
 grep -Fq "local-only first" "$TARGET_REPO/.ai-dev-os/README.md" \
   || fail "ai init did not document the local-first path"
+grep -Fq "default backend は \`tmux\`、lighter path は \`ai start --backend stdio\`" "$TARGET_REPO/.ai-dev-os/README.md" \
+  || fail "ai init did not document backend-aware local-only guidance"
 grep -Fq "PR CI next" "$TARGET_REPO/.ai-dev-os/README.md" \
   || fail "ai init did not document the PR CI path"
 grep -Fq "## Optional GitHub Actions Commands" "$TARGET_REPO/.ai-dev-os/README.md" \
@@ -167,6 +173,8 @@ grep -Fq "GitHub Actions starter generation was skipped for this run via \`--no-
   || fail "ai init --no-github-actions did not explain skipped GitHub Actions generation"
 grep -Fq "this run skipped GitHub Actions via \`--no-github-actions\`" "$NO_GHA_REPO/.ai-dev-os/README.md" \
   || fail "ai init --no-github-actions did not adapt the adoption guide"
+grep -Fq "default backend は \`tmux\`、lighter path は \`ai start --backend stdio\`" "$NO_GHA_REPO/.ai-dev-os/README.md" \
+  || fail "ai init --no-github-actions did not keep backend-aware local-only guidance"
 grep -Fq "use this when you want prompt validation and CLI smoke on pull requests" "$NO_GHA_REPO/.ai-dev-os/README.md" \
   || fail "ai init --no-github-actions lost PR CI adoption reasoning"
 grep -Fq "use this when hosted backend comparison becomes worth the extra credentials and policy surface" "$NO_GHA_REPO/.ai-dev-os/README.md" \

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -277,6 +277,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/99-troubleshooting.md does not mention ai trust remediation"
   grep -Fq "ai start --backend stdio" "$REPO/docs/99-troubleshooting.md" \
     || fail "docs/99-troubleshooting.md does not mention the stdio ai-start escape hatch"
+  grep -Fq "ai start --backend stdio" "$REPO/demo/sample-project/.ai-dev-os/README.md" \
+    || fail "demo starter README does not mention the stdio ai-start option"
   grep -Fq ".ai-dev-os/workflows.yml" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document .ai-dev-os/workflows.yml"
   grep -Fq "ai init" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- align `ai init` next-step output with the ai-start backend contract
- update the generated starter README to present `tmux` as default and `stdio` as the lighter alternative
- keep the demo starter fixture and tests in sync

## Sprint Context
- Issue: Closes #91
- Sprint memory: `tasks/sprint-memory/issue-91.md`
- Review / Demo: generated starter guidance now shows `tmux` default plus `stdio` alternative without changing onboarding order
- System updates: backlog / plans / docs / tests updated

## Verification
- `bash test/ai_init.sh`
- `bash test/demo_assets.sh`
- `bash test/repository_structure.sh`
- `make lint`
- `make test`

## Risk
- low: generated guidance/test-only change; runtime behavior is unchanged
