### PR TITLE
docs: align ai-doctor backend guidance

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #91 `docs: align ai-init starter guidance with ai-start backend options`
-- Branch: `docs/91-ai-init-backend-guidance`
-- Memory Artifact: `tasks/sprint-memory/issue-91.md`
-- Resume Point: generated starter guidance now reflects tmux default plus stdio alternative; next sprint can move to backend-aware doctor or richer starter surfaces
+- Active issue: #93 `docs: make ai-doctor next steps backend-aware`
+- Branch: `docs/93-ai-doctor-backend-guidance`
+- Memory Artifact: `tasks/sprint-memory/issue-93.md`
+- Resume Point: ai-doctor next steps now reflect tmux default plus stdio alternative; next sprint can tighten troubleshooting or move to richer backend surfaces
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align generated starter guidance with the current `ai start` backend contract so first-run artifacts tell the same story as the runtime docs.
+Align `ai doctor` next steps with the current `ai start` backend contract so recovery surfaces tell the same story as launch surfaces.
 
 ## Working Agreement
 
@@ -33,19 +33,18 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - backend-aware `ai init` starter guidance
+  - backend-aware `ai doctor` next steps
   - concrete surfaces
-  - [`bin/ai-init`](./bin/ai-init)
-  - [`demo/sample-project/.ai-dev-os/README.md`](./demo/sample-project/.ai-dev-os/README.md)
+  - [`bin/ai-doctor`](./bin/ai-doctor)
+  - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_init.sh`](./test/ai_init.sh)
-  - [`test/demo_assets.sh`](./test/demo_assets.sh)
+  - [`test/ai_doctor.sh`](./test/ai_doctor.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - generated starter README mentions `tmux` as the current default and `stdio` as an alternative
-  - `ai init` output mentions the backend-aware `ai start` contract
-  - demo starter fixture stays in sync
+  - healthy and warn doctor outputs mention the stdio ai-start alternative
+  - fail-case guidance stays focused on fixing reported gaps first
+  - docs explain the backend-aware doctor footer
   - tests guard the new wording
 
 ## Squad
@@ -60,18 +59,17 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#91` is the sprint slice for this turn
+  - issue `#93` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 36 was added and converted into issue `#91`
+  - Task 37 was added and converted into issue `#93`
 - Review / Demo
-  - show generated starter guidance using tmux default plus stdio alternative
+  - show ai-doctor healthy/warn next steps using tmux default plus stdio alternative
 - Retrospective
-  - keep generated surfaces aligned immediately after runtime/docs changes
+  - keep recovery surfaces aligned right after launch-surface changes
 
 ## Verification
 
-- `bash test/demo_assets.sh`
-- `bash test/ai_init.sh`
+- `bash test/ai_doctor.sh`
 - `bash test/repository_structure.sh`
 - `make lint`
 - `make test`
@@ -79,13 +77,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - align `ai init` output and generated starter README with `tmux` default plus `stdio` alternative
-  - keep the local-first onboarding order unchanged
-  - lock the wording with init/demo/structure guards
+  - align ai-doctor healthy/warn next steps with `tmux` default plus `stdio` alternative
+  - keep the fail case focused on fixing reported gaps first
+  - lock the wording with doctor and structure guards
 - Retrospective
-  - keep: follow top-level docs with generated-surface alignment in the next sprint
-  - change: treat `ai init` output as part of the beginner contract, not just scaffolding noise
-  - stop: leaving generated starter artifacts one backend story behind
+  - keep: follow launch-surface changes with recovery-surface alignment in the next sprint
+  - change: treat ai-doctor footer lines as part of the backend contract once they become guidance
+  - stop: leaving doctor output on an older single-path story
 - System Updates
   - backlog: updated
   - plans: updated
@@ -97,8 +95,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - keeping generated starter surfaces aligned with code-level backend changes
+  - keeping recovery surfaces aligned with code-level backend changes
 - change
-  - move generated-surface follow-through into the next sprint after top-level docs land
+  - move recovery follow-through into the next sprint after launch surfaces land
 - stop
-  - assuming runtime docs are enough once starter artifacts still say less
+  - assuming launch docs are enough once doctor still says less

--- a/bin/ai-doctor
+++ b/bin/ai-doctor
@@ -355,8 +355,10 @@ print_next_steps() {
   fi
   if [[ "$any_warn" -eq 1 ]]; then
     printf '  - if the warnings look acceptable, next: ai start\n'
+    printf '  - if you want a non-tmux path, use: ai start --backend stdio\n'
   else
     printf '  - next: ai start\n'
+    printf '  - optional non-tmux path: ai start --backend stdio\n'
   fi
 }
 

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -57,7 +57,7 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 `ai start` の workspace launch は today は tmux-backed session を default に使うが、その backend は current implementation であり AI Dev OS control plane そのものではない。
 terminal choice を固定したくない時は `ai start --backend stdio` か `AI_WORKSPACE_BACKEND=stdio ai start` を使える。default は引き続き `tmux`。
 project-local scaffold を作りたい時は `ai init` を使う。
-`ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start`、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start`、fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
+`ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start` に加えて `ai start --backend stdio` も案内し、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start` に加えて non-tmux path を案内する。fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。
 launch 挙動は `ai-agent --describe <agent>` や `ai-agent --describe --workflow <name>` で確認できる。
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -615,3 +615,20 @@ Update `bin/ai-init`, keep the demo starter fixture in sync, and extend `test/ai
 
 Expected Impact:
 The first generated artifact a new adopter reads tells the same backend story as the runtime docs and CLI surface.
+
+## Task 37
+
+Title: Make `ai doctor` next steps backend-aware
+Tracking: #93 (closed)
+
+Problem:
+`ai start` now supports `tmux` as the default backend and `stdio` as an alternative, but `ai doctor` still ends with next-step guidance that treats `ai start` as a single undifferentiated path.
+
+Improvement Idea:
+Keep the healthy / warn / fail structure, but mention the stdio alternative in healthy and warn cases without weakening the fail-case remediation.
+
+Implementation Hint:
+Update `bin/ai-doctor`, sync `docs/40-cli.md`, and extend `test/ai_doctor.sh` plus structure guards so the backend-aware guidance stays durable.
+
+Expected Impact:
+Users can move from diagnosis to the right `ai start` path faster, without reading tmux-only intent into the doctor output.

--- a/tasks/sprint-memory/issue-93.md
+++ b/tasks/sprint-memory/issue-93.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#93`
+- branch: `docs/93-ai-doctor-backend-guidance`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: align ai-doctor next-step guidance with the current ai-start backend options
+- decisions:
+  - keep fail-case guidance focused on fixing reported gaps first
+  - add the stdio alternative only to healthy and warn paths
+  - keep the existing ai workflows first-step ordering
+  - update docs and tests together because the footer wording is now part of the contract
+- constraints:
+  - do not weaken actual failure remediation
+  - keep the footer short and terminal-friendly
+  - avoid changing diagnostic content outside the next-step block
+- current state: ai-doctor footer, CLI docs, and tests now mention the stdio alternative in healthy and warn cases, while fail cases stay focused on fixing gaps first
+- next likely moves: run doctor and structure tests, then full verification and closeout
+- open questions: whether a later sprint should make troubleshooting echo the new doctor footer wording more directly
+
+## Lane Notes
+
+- Product / Backlog: turned the post-#91 recovery-surface gap into Task 37 and issue `#93`
+- Delivery / Scrum: kept the sprint to ai-doctor footer wording plus docs/tests
+- Implementer: updating `bin/ai-doctor`, `docs/40-cli.md`, `test/ai_doctor.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: main risk is accidentally suggesting stdio in fail cases where users still need to fix workflow/config gaps first
+
+## Retrospective Output
+
+- keep
+  - following launch-surface changes with recovery-surface updates in the next sprint
+- change
+  - treat ai-doctor footer lines as durable contract once they steer the beginner path
+- stop
+  - leaving doctor output on an older single-path story after ai-start changed
+- follow-ups
+  - consider tightening troubleshooting wording around the new doctor footer if it still feels implicit
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-doctor`
+  - `docs/40-cli.md`
+  - `test/ai_doctor.sh`
+- rerun commands:
+  - `bash test/ai_doctor.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - fail-case guidance must not imply that backend selection can bypass real workflow/config failures

--- a/test/ai_doctor.sh
+++ b/test/ai_doctor.sh
@@ -193,7 +193,8 @@ warn_output="$(
 [[ "$warn_output" == *"next: ai workflows"* ]] || fail "warn ai-doctor output did not point to ai workflows first"
 [[ "$warn_output" == *"optional deeper check: ai-agent --describe --workflow broken_fallback"* ]] || fail "warn ai-doctor output did not include deeper workflow inspection"
 [[ "$warn_output" == *"if the warnings look acceptable, next: ai start"* ]] || fail "warn ai-doctor output did not keep ai start behind the warning check"
-[[ "$(printf '%s\n' "$warn_output" | tail -n 1)" == "  - if the warnings look acceptable, next: ai start" ]] || fail "warn ai-doctor output did not keep next steps at the end of the output"
+[[ "$warn_output" == *"if you want a non-tmux path, use: ai start --backend stdio"* ]] || fail "warn ai-doctor output did not include the stdio alternative"
+[[ "$(printf '%s\n' "$warn_output" | tail -n 1)" == "  - if you want a non-tmux path, use: ai start --backend stdio" ]] || fail "warn ai-doctor output did not keep backend-aware next steps at the end of the output"
 
 mkdir -p "$TEST_REPO/.gemini" "$TEST_HOME/.gemini"
 touch "$TEST_REPO/.gemini/settings.json" "$TEST_HOME/.gemini/settings.json"
@@ -205,8 +206,9 @@ healthy_output="$(
 [[ "$healthy_output" == *"Next Steps"* ]] || fail "healthy ai-doctor output did not print next steps"
 [[ "$healthy_output" == *"next: ai workflows"* ]] || fail "healthy ai-doctor output did not point to ai workflows first"
 [[ "$healthy_output" == *"next: ai start"* ]] || fail "healthy ai-doctor output did not point to ai start second"
+[[ "$healthy_output" == *"optional non-tmux path: ai start --backend stdio"* ]] || fail "healthy ai-doctor output did not include the stdio alternative"
 [[ "$healthy_output" != *"if the warnings look acceptable"* ]] || fail "healthy ai-doctor output should not print warning-specific guidance"
-[[ "$(printf '%s\n' "$healthy_output" | tail -n 1)" == "  - next: ai start" ]] || fail "healthy ai-doctor output did not keep next steps at the end of the output"
+[[ "$(printf '%s\n' "$healthy_output" | tail -n 1)" == "  - optional non-tmux path: ai start --backend stdio" ]] || fail "healthy ai-doctor output did not keep backend-aware next steps at the end of the output"
 
 filtered_output="$(
   cd "$TEST_REPO" && HOME="$TEST_HOME" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-doctor" --workflow native --agent local_reviewer

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -307,7 +307,9 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not document the stdio backend override"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document healthy ai doctor next steps"
-  grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\`" "$REPO/docs/40-cli.md" \
+  grep -Fq "healthy path では \`ai workflows -> ai start\` に加えて \`ai start --backend stdio\`" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document the healthy ai doctor stdio alternative"
+  grep -Fq "warn path では \`ai workflows -> optional ai-agent --describe --workflow <name> -> ai start\` に加えて non-tmux path" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document warn-case ai doctor next steps"
   grep -Fq "fail path では \`fix the reported gaps above -> rerun ai doctor -> ai workflows\`" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document fail-case ai doctor next steps"


### PR DESCRIPTION
## Summary
- make ai-doctor healthy/warn next steps backend-aware
- keep fail-case guidance focused on fixing workflow/config gaps first
- align CLI docs and tests with the updated doctor footer

## Sprint Context
- Issue: Closes #93
- Sprint memory: `tasks/sprint-memory/issue-93.md`
- Review / Demo: ai-doctor now points healthy/warn users to `ai start` and the `stdio` alternative without weakening the fail case
- System updates: backlog / plans / docs / tests updated

## Verification
- `bash test/ai_doctor.sh`
- `bash test/repository_structure.sh`
- `make lint`
- `make test`

## Risk
- low: doctor footer/docs/test-only change; diagnostics and ai-start behavior are unchanged
