### PR TITLE
feat: add stdio recovery to ai start

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #95 `docs: teach ai --help the ai-start backend contract`
-- Branch: `docs/95-ai-help-backend-guidance`
-- Memory Artifact: `tasks/sprint-memory/issue-95.md`
-- Resume Point: ai --help now shows the tmux-default/stdio-alternative backend note; next sprint can decide whether to tighten troubleshooting or backend contract docs further
+- Active issue: #97 `feat: make ai-start tmux failure mention the stdio path`
+- Branch: `feat/97-ai-start-stdio-recovery`
+- Memory Artifact: `tasks/sprint-memory/issue-97.md`
+- Resume Point: ai-start tmux-missing failures now mention the stdio path; next sprint can decide whether any remaining backend-contract surfaces still lag behind
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align `ai --help` with the current `ai start` backend contract so the highest-traffic CLI discovery surface tells the same story as launch and recovery surfaces.
+Align the direct `ai start` tmux-failure path with the current backend contract so launch recovery tells the same story as help, docs, and starter guidance.
 
 ## Working Agreement
 
@@ -33,19 +33,19 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - backend-aware `ai --help` first steps
+  - backend-aware `ai start` tmux-failure recovery
   - concrete surfaces
-  - [`bin/ai`](./bin/ai)
+  - [`bin/ai-start`](./bin/ai-start)
   - [`docs/40-cli.md`](./docs/40-cli.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
   - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - `ai --help` shows a backend note for tmux default plus the stdio alternative
-  - the backend note stays between the runtime and starter first-step lines
-  - docs explain the backend-aware help output
-  - tests guard the new wording and ordering
+  - `ai start` tmux-missing failures mention `ai start --backend stdio`
+  - tmux remediation stays visible alongside the stdio alternative
+  - docs explain the backend-aware failure path
+  - tests guard the new wording
 
 ## Squad
 
@@ -59,13 +59,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#95` is the sprint slice for this turn
+  - issue `#97` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 38 was added and converted into issue `#95`
+  - Task 39 was added and converted into issue `#97`
 - Review / Demo
-  - show `ai --help` with the backend note between the runtime and starter first-step paths
+  - show the `ai start` tmux-missing failure with both tmux remediation and the stdio alternative
 - Retrospective
-  - keep high-traffic discovery surfaces aligned right after backend contract changes
+  - keep recovery surfaces aligned after backend contract changes, not just docs and help
 
 ## Verification
 
@@ -77,13 +77,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - align `ai --help` first steps with `tmux` default plus `stdio` alternative
-  - keep the backend note between the runtime and starter paths
+  - align `ai start` tmux-missing failures with `tmux` default plus `stdio` alternative
+  - keep tmux remediation visible while adding the stdio fallback
   - lock the wording with CLI and structure guards
 - Retrospective
-  - keep: follow backend-contract changes through the highest-traffic surfaces first
-  - change: treat `ai --help` first-step lines as part of the durable backend contract
-  - stop: leaving help output on an older single-path story after other surfaces changed
+  - keep: follow backend-contract changes through recovery surfaces as soon as they become user-facing guidance
+  - change: treat `ai start` failure stderr as part of the durable backend contract once it teaches a fallback
+  - stop: leaving launch failures on an older tmux-only recovery story
 - System Updates
   - backlog: updated
   - plans: updated
@@ -95,8 +95,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - keeping high-traffic CLI discovery aligned with backend changes
+  - keeping direct launch recovery aligned with backend changes
 - change
-  - update `ai --help` immediately after launch and recovery surfaces change
+  - update `ai start` failure guidance immediately after new backend options are introduced
 - stop
-  - assuming deeper docs can carry backend nuance when `ai --help` still hides it
+  - assuming troubleshooting docs are enough when the direct launch failure still says less

--- a/bin/ai-start
+++ b/bin/ai-start
@@ -35,12 +35,16 @@ platform_remediation() {
 require_command() {
   local name="$1"
   local remediation="$2"
+  local alternative="${3:-}"
 
   if command -v "$name" >/dev/null 2>&1; then
     return 0
   fi
 
   echo "missing dependency: $name ($remediation)" >&2
+  if [[ -n "$alternative" ]]; then
+    echo "$alternative" >&2
+  fi
   exit 1
 }
 
@@ -112,7 +116,7 @@ fi
 
 case "$backend_name" in
   tmux)
-    require_command tmux "$(platform_remediation)"
+    require_command tmux "$(platform_remediation)" "if you only need a non-tmux path: ai start --backend stdio"
     if ! tmux has-session -t "$session_name" >/dev/null 2>&1; then
       tmux new-session -d -s "$session_name" -n "$window_name" -c "$target_repo"
       tmux split-window -v -t "$session_name:$window_name.1" -c "$target_repo"

--- a/docs/40-cli.md
+++ b/docs/40-cli.md
@@ -56,6 +56,7 @@ trust 設定は beginner surface の常時コマンドというより、`ai doct
 `ai start` の起動後は、まず `ai doctor` と `ai workflows` を見れば beginner path に戻りやすい。
 `ai start` の workspace launch は today は tmux-backed session を default に使うが、その backend は current implementation であり AI Dev OS control plane そのものではない。
 terminal choice を固定したくない時は `ai start --backend stdio` か `AI_WORKSPACE_BACKEND=stdio ai start` を使える。default は引き続き `tmux`。
+default の tmux path が missing dependency で止まった時も、`ai start` は `make install` に加えて `ai start --backend stdio` を案内する。
 project-local scaffold を作りたい時は `ai init` を使う。
 `ai doctor` は workflow resolution、missing binary、missing prompt/config、fallback path、vendor-native runtime path (`project_config`, `user_config`, `mcp_config`, `project_extensions`) を human-readable に返す。healthy path では `ai workflows -> ai start` に加えて `ai start --backend stdio` も案内し、warn path では `ai workflows -> optional ai-agent --describe --workflow <name> -> ai start` に加えて non-tmux path を案内する。fail path では `fix the reported gaps above -> rerun ai doctor -> ai workflows` の next step を最後に返す。
 `ai code` / `ai review` / `ai improve` は agent metadata にある `prompt_file` と `.context/summary.md` を使って vendor CLI に自然な形で handoff する。

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -649,3 +649,20 @@ Update `bin/ai`, sync `docs/40-cli.md`, and extend `test/ai_cli.sh` plus structu
 
 Expected Impact:
 Users can discover the non-tmux path from `ai --help` without losing the beginner-first ordering or the current tmux-default story.
+
+## Task 39
+
+Title: Make `ai start` tmux-failure recovery mention the stdio path
+Tracking: #97 (closed)
+
+Problem:
+`ai start` now supports `tmux` as the default backend and `stdio` as an alternative, but the direct tmux-missing failure path still only points users at installation remediation. That leaves the launch surface itself weaker than the rest of the backend-aware story.
+
+Improvement Idea:
+Keep the current tmux remediation, but also mention `ai start --backend stdio` when the failure is specifically about the default tmux backend being unavailable.
+
+Implementation Hint:
+Update `bin/ai-start`, sync `docs/40-cli.md` or troubleshooting wording if needed, and extend `test/ai_cli.sh` so the failure contract stays explicit.
+
+Expected Impact:
+Users can recover from a missing tmux dependency faster without reading the tmux default as a hard product requirement.

--- a/tasks/sprint-memory/issue-97.md
+++ b/tasks/sprint-memory/issue-97.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#97`
+- branch: `feat/97-ai-start-stdio-recovery`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: align the direct `ai start` tmux-missing failure path with the current backend options
+- decisions:
+  - keep tmux as the default backend and keep its install remediation visible
+  - add the stdio alternative only when the failure is specifically about missing tmux
+  - treat stderr guidance as part of the backend contract once it teaches a fallback
+  - keep the wording short and terminal-friendly
+- constraints:
+  - do not weaken the current tmux remediation
+  - do not imply that stdio replaces tmux as the default
+  - avoid broad restructuring of `ai-start`
+- current state: `ai-start` now mentions `ai start --backend stdio` on tmux-missing failures, and docs/tests lock the wording down
+- next likely moves: verify CLI and structure tests, then decide whether any backend-aware edge surfaces still remain
+- open questions: whether future backends should share a more general missing-backend remediation contract
+
+## Lane Notes
+
+- Product / Backlog: turned the remaining launch-recovery gap into Task 39 and issue `#97`
+- Delivery / Scrum: kept the sprint to one stderr contract plus matching docs/tests
+- Implementer: updating `bin/ai-start`, `docs/40-cli.md`, `test/ai_cli.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: main risk is over-suggesting stdio in contexts where tmux remediation should stay primary
+
+## Retrospective Output
+
+- keep
+  - following backend changes through the most direct user-facing failure surfaces
+- change
+  - treat launch stderr as durable contract when it teaches fallback paths
+- stop
+  - assuming troubleshooting docs are enough while the direct failure path still looks stricter than the product is
+- follow-ups
+  - consider whether future backend adapters need a shared remediation helper once more than two backends exist
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-start`
+  - `docs/40-cli.md`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - tmux remediation must remain visible and primary even after adding the stdio fallback

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -384,6 +384,7 @@ start_failure="$(
 )"
 [[ "$start_failure" == *"missing dependency: tmux"* ]] || fail "ai-start did not explain missing tmux"
 [[ "$start_failure" == *"run: make install (from the AI Dev OS runtime repo)"* ]] || fail "ai-start did not show tmux remediation"
+[[ "$start_failure" == *"if you only need a non-tmux path: ai start --backend stdio"* ]] || fail "ai-start did not show the stdio alternative on tmux failure"
 
 (
   cd "$GLOBAL_REPO"

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -305,6 +305,8 @@ verify_ai_dev_os_docs() {
     || fail "docs/40-cli.md does not document ai workflows next-step guidance"
   grep -Fq "workspace launch は today は tmux-backed session を default に使う" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document the current tmux-backed ai-start implementation"
+  grep -Fq "default の tmux path が missing dependency で止まった時も" "$REPO/docs/40-cli.md" \
+    || fail "docs/40-cli.md does not document the ai-start tmux-failure stdio guidance"
   grep -Fq "ai start --backend stdio" "$REPO/docs/40-cli.md" \
     || fail "docs/40-cli.md does not document the stdio backend override"
   grep -Fq "healthy path では \`ai workflows -> ai start\`" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- add a stdio fallback note to the tmux-missing `ai start` failure path
- keep tmux remediation visible while making the backend contract explicit
- sync CLI docs, guards, plans, backlog, and sprint memory

## Testing
- bash test/ai_cli.sh
- bash test/repository_structure.sh
- make lint
- make test

Closes #97
