### PR TITLE
docs: align demo readme with backend guidance

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #99 `docs: teach ai-start --help the backend choice contract`
-- Branch: `docs/99-ai-start-help-backend-contract`
-- Memory Artifact: `tasks/sprint-memory/issue-99.md`
-- Resume Point: ai-start --help now explains tmux default, stdio alternative, and the env override; next sprint can move to the remaining demo/backend drift if any still matters
+- Active issue: #101 `docs: make demo sample-project README backend-aware`
+- Branch: `docs/101-demo-readme-backend-guidance`
+- Memory Artifact: `tasks/sprint-memory/issue-101.md`
+- Resume Point: demo sample-project README now explains tmux default plus the stdio alternative; next sprint can decide whether the remaining foundation work is finished or if one more polish slice is worthwhile
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align `ai-start --help` with the current backend contract so the command-specific help surface tells the same story as launch, recovery, and docs.
+Align the demo sample-project README with the current backend contract so the staged fixture entrypoint tells the same story as the starter README, walkthrough, and CLI surfaces.
 
 ## Working Agreement
 
@@ -33,19 +33,17 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - backend-aware `ai-start --help`
+  - backend-aware demo sample-project README
   - concrete surfaces
-  - [`bin/ai-start`](./bin/ai-start)
-  - [`docs/40-cli.md`](./docs/40-cli.md)
+  - [`demo/sample-project/README.md`](./demo/sample-project/README.md)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - [`test/demo_assets.sh`](./test/demo_assets.sh)
   - [`test/repository_structure.sh`](./test/repository_structure.sh)
   - acceptance slice
-  - `ai-start --help` mentions the tmux default
-  - `ai-start --help` mentions the stdio alternative and env override
-  - docs explain the backend-aware help output
-  - tests guard the new wording and ordering
+  - the demo README says `tmux` is the current default backend
+  - the demo README mentions `ai start --repo demo/sample-project --backend stdio`
+  - demo and structure tests guard the wording and order
 
 ## Squad
 
@@ -59,17 +57,17 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#99` is the sprint slice for this turn
+  - issue `#101` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 40 was added and converted into issue `#99`
+  - Task 41 was added and converted into issue `#101`
 - Review / Demo
-  - show `ai-start --help` with tmux default, stdio alternative, and the env override
+  - show Stage 3 of `demo/sample-project/README.md` with tmux default plus the stdio alternative
 - Retrospective
-  - keep command-specific help aligned right after backend contract changes
+  - keep the staged demo entrypoint aligned right after backend contract changes
 
 ## Verification
 
-- `bash test/ai_cli.sh`
+- `bash test/demo_assets.sh`
 - `bash test/repository_structure.sh`
 - `make lint`
 - `make test`
@@ -77,13 +75,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - align `ai-start --help` with `tmux` default plus `stdio` alternative
-  - keep the env override visible without turning help into a long tutorial
-  - lock the wording with CLI and structure guards
+  - align the demo sample-project Stage 3 wording with `tmux` default plus `stdio` alternative
+  - keep the staged local-first flow intact while removing tmux-only wording
+  - lock the wording with demo and structure guards
 - Retrospective
-  - keep: follow backend-contract changes through command-specific help as soon as a command gains multiple viable paths
-  - change: treat `ai-start --help` as a durable contract once it teaches backend selection
-  - stop: relying on broad docs when the command's own help still says less
+  - keep: follow backend-contract changes through every newcomer-facing surface, including demo fixtures
+  - change: treat the demo README as a durable contract once it becomes the sample staged adoption entrypoint
+  - stop: leaving the demo surface on an older tmux-only story after the product has moved on
 - System Updates
   - backlog: updated
   - plans: updated
@@ -95,8 +93,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - keeping command-specific help aligned with backend changes
+  - keeping the staged demo entrypoint aligned with backend changes
 - change
-  - update `ai-start --help` immediately after new backend options are introduced
+  - update demo fixture wording immediately after backend options change
 - stop
-  - assuming broader docs are enough when command help still hides backend choice
+  - assuming walkthroughs are enough when the demo README still hides backend choice

--- a/demo/sample-project/README.md
+++ b/demo/sample-project/README.md
@@ -33,7 +33,8 @@ ai start --repo demo/sample-project
 
 Expected result:
 
-- a tmux-based AI Dev OS workspace opens
+- the current default backend is `tmux`
+- `ai start --repo demo/sample-project --backend stdio` is the lighter non-tmux alternative
 - repo-local `.ai-dev-os/` config is used
 - the context pane is refreshed for this fixture
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -683,3 +683,20 @@ Update `bin/ai-start`, sync `docs/40-cli.md`, and extend `test/ai_cli.sh` plus s
 
 Expected Impact:
 Users can discover the right launch mode directly from `ai-start --help` instead of inferring it from broader docs or trial and error.
+
+## Task 41
+
+Title: Make the demo sample-project README backend-aware
+Tracking: #101 (closed)
+
+Problem:
+`ai start` now supports `tmux` as the default backend and `stdio` as an alternative, but `demo/sample-project/README.md` still describes Stage 3 as if the demo workspace is tmux-only.
+
+Improvement Idea:
+Keep the staged demo flow intact, but make Stage 3 say that `tmux` is the current default backend and `ai start --backend stdio` is the lighter non-tmux alternative.
+
+Implementation Hint:
+Update `demo/sample-project/README.md`, extend `test/demo_assets.sh`, and add a narrow repository-structure guard so the sample entrypoint stays aligned with the backend contract.
+
+Expected Impact:
+The demo fixture tells the same backend story as the starter README, walkthrough, and CLI surfaces, so the sample no longer reads like tmux is mandatory.

--- a/tasks/sprint-memory/issue-101.md
+++ b/tasks/sprint-memory/issue-101.md
@@ -1,0 +1,67 @@
+# Sprint
+
+- issue: `#101`
+- branch: `docs/101-demo-readme-backend-guidance`
+- date: `2026-03-11`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: align the demo sample-project README with the current `ai start` backend contract
+- decisions:
+  - keep the staged demo flow unchanged
+  - describe `tmux` as the current default backend in Stage 3
+  - mention `ai start --repo demo/sample-project --backend stdio` as the lighter non-tmux alternative
+  - update demo and structure guards together because the sample README is now part of the backend contract
+- constraints:
+  - do not rewrite the whole demo README
+  - preserve the local-first stage ordering
+  - keep wording consistent with the starter README and walkthrough
+- current state: the demo README, demo asset test, and structure guard now expose the tmux-default plus stdio-alternative story directly in Stage 3
+- next likely moves: verify demo and structure tests, then decide whether any remaining foundation drift is worth another sprint
+- open questions: whether the foundation phase is complete enough to switch fully into expansion work after this slice
+
+## Lane Notes
+
+- Product / Backlog: turned the remaining demo-surface drift into Task 41 and issue `#101`
+- Delivery / Scrum: kept the sprint to one sample README plus matching guards
+- Implementer: updating `demo/sample-project/README.md`, `test/demo_assets.sh`, and `test/repository_structure.sh`
+- Reviewer / QA: main risk is drifting from the already-aligned walkthrough or starter README wording
+
+## Retrospective Output
+
+- keep
+  - following backend changes through every newcomer-facing surface, including fixtures
+- change
+  - treat the demo README as contract once it acts as the sample staged-adoption entrypoint
+- stop
+  - assuming the walkthrough is enough while the sample README still reads more rigidly
+- follow-ups
+  - decide whether the foundation phase is now complete or if one more polish sprint is still justified
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: updated
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `demo/sample-project/README.md`
+  - `test/demo_assets.sh`
+  - `test/repository_structure.sh`
+- rerun commands:
+  - `bash test/demo_assets.sh`
+  - `bash test/repository_structure.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - the Stage 3 wording must stay aligned with the walkthrough and starter README without over-explaining

--- a/test/demo_assets.sh
+++ b/test/demo_assets.sh
@@ -64,6 +64,10 @@ grep -Fq "ai workflows" "$REPO/demo/sample-project/README.md" \
   || fail "demo README missing ai workflows"
 grep -Fq "ai start --repo demo/sample-project" "$REPO/demo/sample-project/README.md" \
   || fail "demo README missing ai start"
+grep -Fq "current default backend is \`tmux\`" "$REPO/demo/sample-project/README.md" \
+  || fail "demo README missing the tmux-default backend note"
+grep -Fq "ai start --repo demo/sample-project --backend stdio" "$REPO/demo/sample-project/README.md" \
+  || fail "demo README missing the stdio ai-start alternative"
 grep -Fq "docs/42-github-actions.md" "$REPO/demo/sample-project/README.md" \
   || fail "demo README missing CI/runtime guidance"
 grep -Fq "make doctor" "$REPO/demo/sample-project/README.md" \
@@ -73,6 +77,8 @@ assert_in_order "$REPO/demo/sample-project/README.md" "## Stage 2: inspect the l
 assert_in_order "$REPO/demo/sample-project/README.md" "## Stage 3: start the workspace" "## Stage 4: optional prompt check"
 assert_in_order "$REPO/demo/sample-project/README.md" "ai doctor" "ai workflows"
 assert_in_order "$REPO/demo/sample-project/README.md" "ai workflows" "ai start --repo demo/sample-project"
+assert_in_order "$REPO/demo/sample-project/README.md" "ai start --repo demo/sample-project" "current default backend is \`tmux\`"
+assert_in_order "$REPO/demo/sample-project/README.md" "current default backend is \`tmux\`" "ai start --repo demo/sample-project --backend stdio"
 
 grep -Fq "ai start" "$REPO/docs/05-demo-walkthrough.md" \
   || fail "walkthrough missing ai start"

--- a/test/repository_structure.sh
+++ b/test/repository_structure.sh
@@ -277,6 +277,10 @@ verify_ai_dev_os_docs() {
     || fail "docs/99-troubleshooting.md does not mention ai trust remediation"
   grep -Fq "ai start --backend stdio" "$REPO/docs/99-troubleshooting.md" \
     || fail "docs/99-troubleshooting.md does not mention the stdio ai-start escape hatch"
+  grep -Fq "current default backend is \`tmux\`" "$REPO/demo/sample-project/README.md" \
+    || fail "demo sample-project README does not describe tmux as the current default backend"
+  grep -Fq "ai start --repo demo/sample-project --backend stdio" "$REPO/demo/sample-project/README.md" \
+    || fail "demo sample-project README does not mention the stdio ai-start alternative"
   grep -Fq "ai start --backend stdio" "$REPO/demo/sample-project/.ai-dev-os/README.md" \
     || fail "demo starter README does not mention the stdio ai-start option"
   grep -Fq ".ai-dev-os/workflows.yml" "$REPO/docs/40-cli.md" \


### PR DESCRIPTION
## Summary
- make the demo sample-project Stage 3 backend-aware
- sync demo and structure guards with the tmux-default plus stdio-alternative wording
- record the sprint closeout in plans, backlog, and sprint memory

## Testing
- bash test/demo_assets.sh
- bash test/repository_structure.sh
- make lint
- make test

Closes #101
