### PR TITLE
chore: refactor ai-start backend helpers

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #101 `docs: make demo sample-project README backend-aware`
-- Branch: `docs/101-demo-readme-backend-guidance`
-- Memory Artifact: `tasks/sprint-memory/issue-101.md`
-- Resume Point: demo sample-project README now explains tmux default plus the stdio alternative; next sprint can decide whether the remaining foundation work is finished or if one more polish slice is worthwhile
+- Active issue: #103 `chore: refactor ai-start backend handling into helpers`
+- Branch: `chore/103-ai-start-backend-helpers`
+- Memory Artifact: `tasks/sprint-memory/issue-103.md`
+- Resume Point: ai-start now routes backend validation, stop, launch, and attach behavior through helpers; next sprint can either keep polishing shell internals or shift fully into expansion work
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Align the demo sample-project README with the current backend contract so the staged fixture entrypoint tells the same story as the starter README, walkthrough, and CLI surfaces.
+Refactor `ai-start` backend handling so the code stays easy to read and extend without changing the current tmux/stdio contract.
 
 ## Working Agreement
 
@@ -33,17 +33,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - backend-aware demo sample-project README
+  - cleaner `ai-start` backend orchestration
   - concrete surfaces
-  - [`demo/sample-project/README.md`](./demo/sample-project/README.md)
+  - [`bin/ai-start`](./bin/ai-start)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/demo_assets.sh`](./test/demo_assets.sh)
-  - [`test/repository_structure.sh`](./test/repository_structure.sh)
+  - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - acceptance slice
-  - the demo README says `tmux` is the current default backend
-  - the demo README mentions `ai start --repo demo/sample-project --backend stdio`
-  - demo and structure tests guard the wording and order
+  - `ai-start` keeps the current tmux/stdio behavior unchanged
+  - backend validation, stop, launch, and attach logic move into clearer helpers
+  - tests lock the refactor with at least one explicit edge-case assertion
 
 ## Squad
 
@@ -57,31 +56,30 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#101` is the sprint slice for this turn
+  - issue `#103` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 41 was added and converted into issue `#101`
+  - Task 42 was added and converted into issue `#103`
 - Review / Demo
-  - show Stage 3 of `demo/sample-project/README.md` with tmux default plus the stdio alternative
+  - show `bin/ai-start` reading as helper-based orchestration while keeping the same tmux/stdio behavior
 - Retrospective
-  - keep the staged demo entrypoint aligned right after backend contract changes
+  - keep code cleanup moving once the surface-level contract settles
 
 ## Verification
 
-- `bash test/demo_assets.sh`
-- `bash test/repository_structure.sh`
+- `bash test/ai_cli.sh`
 - `make lint`
 - `make test`
 
 ## Closeout
 
 - Review / Demo
-  - align the demo sample-project Stage 3 wording with `tmux` default plus `stdio` alternative
-  - keep the staged local-first flow intact while removing tmux-only wording
-  - lock the wording with demo and structure guards
+  - refactor `ai-start` into backend helpers without changing the tmux/stdio contract
+  - keep help, start, stop, attach, and failure behavior stable
+  - lock the refactor with CLI tests, including the unknown-backend path
 - Retrospective
-  - keep: follow backend-contract changes through every newcomer-facing surface, including demo fixtures
-  - change: treat the demo README as a durable contract once it becomes the sample staged adoption entrypoint
-  - stop: leaving the demo surface on an older tmux-only story after the product has moved on
+  - keep: use small refactors once product wording has stabilized
+  - change: add one extra edge-case assertion when refactoring shell control flow
+  - stop: leaving backend branching to grow linearly inside one script body
 - System Updates
   - backlog: updated
   - plans: updated
@@ -93,8 +91,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - keeping the staged demo entrypoint aligned with backend changes
+  - cleaning shell control flow once outward behavior is stable
 - change
-  - update demo fixture wording immediately after backend options change
+  - lock refactors with a targeted edge-case assertion instead of relying only on happy-path coverage
 - stop
-  - assuming walkthroughs are enough when the demo README still hides backend choice
+  - allowing backend orchestration logic to keep spreading across repeated case blocks

--- a/bin/ai-start
+++ b/bin/ai-start
@@ -29,6 +29,18 @@ Hints:
 EOF
 }
 
+is_supported_backend() {
+  local candidate="${1:-}"
+  case "$candidate" in
+    tmux|stdio)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 platform_remediation() {
   case "$(uname -s)" in
     Darwin)
@@ -54,6 +66,84 @@ require_command() {
     echo "$alternative" >&2
   fi
   exit 1
+}
+
+validate_backend() {
+  local candidate="$1"
+
+  if is_supported_backend "$candidate"; then
+    return 0
+  fi
+
+  echo "unknown workspace backend: $candidate" >&2
+  usage >&2
+  exit 2
+}
+
+stop_workspace_backend() {
+  local backend="$1"
+  local session="$2"
+
+  case "$backend" in
+    tmux)
+      require_command tmux "$(platform_remediation)"
+      if tmux has-session -t "$session" >/dev/null 2>&1; then
+        tmux kill-session -t "$session"
+      fi
+      ;;
+    stdio)
+      ;;
+  esac
+}
+
+launch_tmux_workspace() {
+  local session="$1"
+  local window="$2"
+  local repo="$3"
+  local context_cmd="$4"
+
+  require_command tmux "$(platform_remediation)" "if you only need a non-tmux path: ai start --backend stdio"
+  if ! tmux has-session -t "$session" >/dev/null 2>&1; then
+    tmux new-session -d -s "$session" -n "$window" -c "$repo"
+    tmux split-window -v -t "$session:$window.1" -c "$repo"
+    tmux send-keys -t "$session:$window.2" "$context_cmd" C-m
+    tmux select-layout -t "$session:$window" "${AI_TMUX_LAYOUT_PRESET:-tiled}"
+    tmux select-pane -t "$session:$window.1"
+  fi
+
+  printf '%s\n' "$session"
+}
+
+launch_workspace_backend() {
+  local backend="$1"
+  local session="$2"
+  local window="$3"
+  local repo="$4"
+  local context_cmd="$5"
+
+  case "$backend" in
+    tmux)
+      launch_tmux_workspace "$session" "$window" "$repo" "$context_cmd"
+      ;;
+    stdio)
+      printf 'stdio\n'
+      ;;
+  esac
+}
+
+attach_workspace_backend() {
+  local backend="$1"
+  local session="$2"
+
+  case "$backend" in
+    tmux)
+      if [[ -t 1 && -z "${TMUX:-}" ]]; then
+        exec tmux attach-session -t "$session"
+      fi
+      ;;
+    stdio)
+      ;;
+  esac
 }
 
 repo_path=""
@@ -87,15 +177,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-case "$backend_name" in
-  tmux|stdio)
-    ;;
-  *)
-    echo "unknown workspace backend: $backend_name" >&2
-    usage >&2
-    exit 2
-    ;;
-esac
+validate_backend "$backend_name"
 
 target_repo="$(ai_target_repo_root "${repo_path:-$PWD}")"
 window_name="${AI_TMUX_WINDOW_NAME:-workspace}"
@@ -104,16 +186,7 @@ session_name="$(ai_session_name "$target_repo" "$TMUX_LAYOUT")"
 context_command="$REPO_ROOT/bin/ai-context --repo $target_repo --show"
 
 if [[ $stop_requested -eq 1 ]]; then
-  case "$backend_name" in
-    tmux)
-      require_command tmux "$(platform_remediation)"
-      if tmux has-session -t "$session_name" >/dev/null 2>&1; then
-        tmux kill-session -t "$session_name"
-      fi
-      ;;
-    stdio)
-      ;;
-  esac
+  stop_workspace_backend "$backend_name" "$session_name"
   exit 0
 fi
 
@@ -122,22 +195,7 @@ if ! "$REPO_ROOT/bin/ai-context" --repo "$target_repo" >/dev/null; then
   exit 1
 fi
 
-case "$backend_name" in
-  tmux)
-    require_command tmux "$(platform_remediation)" "if you only need a non-tmux path: ai start --backend stdio"
-    if ! tmux has-session -t "$session_name" >/dev/null 2>&1; then
-      tmux new-session -d -s "$session_name" -n "$window_name" -c "$target_repo"
-      tmux split-window -v -t "$session_name:$window_name.1" -c "$target_repo"
-      tmux send-keys -t "$session_name:$window_name.2" "$context_command" C-m
-      tmux select-layout -t "$session_name:$window_name" "${AI_TMUX_LAYOUT_PRESET:-tiled}"
-      tmux select-pane -t "$session_name:$window_name.1"
-    fi
-    workspace_label="$session_name"
-    ;;
-  stdio)
-    workspace_label="stdio"
-    ;;
-esac
+workspace_label="$(launch_workspace_backend "$backend_name" "$session_name" "$window_name" "$target_repo" "$context_command")"
 
 printf 'AI Dev OS workspace ready: %s\n' "$workspace_label"
 printf 'Workspace: %s\n' "$target_repo"
@@ -145,6 +203,4 @@ printf 'Backend: %s\n' "$backend_name"
 printf 'Next: ai doctor | ai workflows\n'
 printf 'Then: ai code | ai review | ai task | ai agents\n'
 
-if [[ "$backend_name" == "tmux" && -t 1 && -z "${TMUX:-}" ]]; then
-  exec tmux attach-session -t "$session_name"
-fi
+attach_workspace_backend "$backend_name" "$session_name"

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -700,3 +700,20 @@ Update `demo/sample-project/README.md`, extend `test/demo_assets.sh`, and add a 
 
 Expected Impact:
 The demo fixture tells the same backend story as the starter README, walkthrough, and CLI surfaces, so the sample no longer reads like tmux is mandatory.
+
+## Task 42
+
+Title: Refactor `ai-start` backend handling into dedicated helpers
+Tracking: #103 (closed)
+
+Problem:
+`ai-start` now carries backend validation, help text, stop handling, launch handling, and attach behavior in one linear script body. The behavior is still small, but the branching is starting to scatter the backend contract across multiple case blocks.
+
+Improvement Idea:
+Keep the current `tmux` / `stdio` behavior exactly the same, but move backend-specific work into small helpers so the control flow reads as one orchestration path instead of repeated branching.
+
+Implementation Hint:
+Refactor `bin/ai-start` around helper functions for backend validation, stop handling, launch handling, and attach behavior. Extend `test/ai_cli.sh` with at least one extra assertion that locks unknown-backend behavior down during the refactor.
+
+Expected Impact:
+`ai-start` stays behaviorally stable while becoming easier to read, test, and extend if more backends or launch nuances appear later.

--- a/tasks/sprint-memory/issue-103.md
+++ b/tasks/sprint-memory/issue-103.md
@@ -1,0 +1,65 @@
+# Sprint
+
+- issue: `#103`
+- branch: `chore/103-ai-start-backend-helpers`
+- date: `2026-03-12`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: refactor `ai-start` backend handling into clearer helpers without changing behavior
+- decisions:
+  - keep the tmux/stdio contract byte-for-byte compatible where practical
+  - split backend validation, stop, launch, and attach behavior into dedicated helpers
+  - add one explicit unknown-backend assertion so the refactor is not protected only by happy-path tests
+  - keep the refactor local to `bin/ai-start` and `test/ai_cli.sh`
+- constraints:
+  - do not change the current backend semantics
+  - do not broaden the sprint into docs or new backends
+  - keep the script readable for shell-level maintenance
+- current state: `ai-start` reads as orchestration over helpers instead of repeated backend case blocks, and CLI tests cover the unknown-backend edge path
+- next likely moves: decide whether to keep polishing shell internals or move focus to new functionality
+- open questions: whether a later shell cleanup should extract shared backend phrasing into a reusable helper layer across commands
+
+## Lane Notes
+
+- Product / Backlog: turned the code-cleanliness ask into Task 42 and issue `#103`
+- Delivery / Scrum: kept the sprint to one shell script plus one targeted test addition
+- Implementer: updating `bin/ai-start` and `test/ai_cli.sh`
+- Reviewer / QA: main risk is accidentally changing stdout/stderr or attach behavior while simplifying control flow
+
+## Retrospective Output
+
+- keep
+  - switching to small refactors once outward contract work settles
+- change
+  - add a targeted edge-case assertion whenever shell control flow is rearranged
+- stop
+  - letting backend orchestration keep spreading across repeated case blocks
+- follow-ups
+  - consider whether future shell cleanup should share backend phrasing more centrally across commands
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: not needed
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-start`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - refactor must not alter tmux attach behavior or the current stderr contract

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -392,6 +392,12 @@ stdio_output="$(PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TES
 [[ "$(cat "$TMUX_LOG")" == "$tmux_log_before_stdio" ]] || fail "ai-start stdio backend unexpectedly touched tmux"
 PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TEST_REPO" --backend stdio --stop >/dev/null
 
+unknown_backend_failure="$(
+  PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-start" --repo "$TEST_REPO" --backend invalid 2>&1 >/dev/null || true
+)"
+[[ "$unknown_backend_failure" == *"unknown workspace backend: invalid"* ]] || fail "ai-start did not keep the unknown-backend error"
+[[ "$unknown_backend_failure" == *"usage: ai-start [--repo PATH] [--backend <tmux|stdio>] [--stop]"* ]] || fail "ai-start did not keep usage in the unknown-backend error"
+
 start_failure="$(
   PATH="$STUB_BIN:/usr/bin:/bin" "$REPO/bin/ai-start" --repo "$TEST_REPO" 2>&1 >/dev/null || true
 )"


### PR DESCRIPTION
## Summary
- refactor `ai-start` backend validation, stop, launch, and attach paths into dedicated helpers
- keep the tmux/stdio contract stable while reducing repeated branching
- add explicit unknown-backend coverage and record the sprint closeout

## Testing
- bash test/ai_cli.sh
- make lint
- make test

Closes #103
