### PR TITLE
chore: refactor ai-doctor runtime helpers

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #103 `chore: refactor ai-start backend handling into helpers`
-- Branch: `chore/103-ai-start-backend-helpers`
-- Memory Artifact: `tasks/sprint-memory/issue-103.md`
-- Resume Point: ai-start now routes backend validation, stop, launch, and attach behavior through helpers; next sprint can either keep polishing shell internals or shift fully into expansion work
+- Active issue: #105 `chore: refactor ai-doctor runtime status helpers`
+- Branch: `chore/105-ai-doctor-runtime-helpers`
+- Memory Artifact: `tasks/sprint-memory/issue-105.md`
+- Resume Point: ai-doctor now reports runtime config and extension status through helpers; next sprint can either keep tightening shell internals or move into expansion work
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Refactor `ai-start` backend handling so the code stays easy to read and extend without changing the current tmux/stdio contract.
+Refactor `ai-doctor` runtime status reporting so the code stays easy to read and extend without changing the current diagnostics contract.
 
 ## Working Agreement
 
@@ -33,16 +33,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - cleaner `ai-start` backend orchestration
+  - cleaner `ai-doctor` runtime status reporting
   - concrete surfaces
-  - [`bin/ai-start`](./bin/ai-start)
+  - [`bin/ai-doctor`](./bin/ai-doctor)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - [`test/ai_doctor.sh`](./test/ai_doctor.sh)
   - acceptance slice
-  - `ai-start` keeps the current tmux/stdio behavior unchanged
-  - backend validation, stop, launch, and attach logic move into clearer helpers
-  - tests lock the refactor with at least one explicit edge-case assertion
+  - `ai-doctor` keeps current runtime-status output unchanged
+  - repeated file/directory-backed status reporting moves into clearer helpers
+  - tests lock the refactor with at least one explicit filtered-output assertion
 
 ## Squad
 
@@ -56,30 +56,30 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#103` is the sprint slice for this turn
+  - issue `#105` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 42 was added and converted into issue `#103`
+  - Task 43 was added and converted into issue `#105`
 - Review / Demo
-  - show `bin/ai-start` reading as helper-based orchestration while keeping the same tmux/stdio behavior
+  - show `bin/ai-doctor` reading as helper-based runtime status reporting while keeping the same diagnostics
 - Retrospective
-  - keep code cleanup moving once the surface-level contract settles
+  - keep shell cleanup moving once user-facing contracts settle
 
 ## Verification
 
-- `bash test/ai_cli.sh`
+- `bash test/ai_doctor.sh`
 - `make lint`
 - `make test`
 
 ## Closeout
 
 - Review / Demo
-  - refactor `ai-start` into backend helpers without changing the tmux/stdio contract
-  - keep help, start, stop, attach, and failure behavior stable
-  - lock the refactor with CLI tests, including the unknown-backend path
+  - refactor `ai-doctor` runtime status reporting into helpers without changing doctor output
+  - keep project/user/mcp/extensions diagnostics stable
+  - lock the refactor with doctor tests, including filtered-output coverage
 - Retrospective
   - keep: use small refactors once product wording has stabilized
-  - change: add one extra edge-case assertion when refactoring shell control flow
-  - stop: leaving backend branching to grow linearly inside one script body
+  - change: add one extra targeted assertion whenever shell diagnostics are rearranged
+  - stop: letting repeated runtime-status reporting keep growing inline
 - System Updates
   - backlog: updated
   - plans: updated
@@ -91,8 +91,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - cleaning shell control flow once outward behavior is stable
+  - cleaning shell diagnostics once outward behavior is stable
 - change
-  - lock refactors with a targeted edge-case assertion instead of relying only on happy-path coverage
+  - lock refactors with a targeted filtered-output assertion instead of relying only on broad coverage
 - stop
-  - allowing backend orchestration logic to keep spreading across repeated case blocks
+  - allowing runtime-status reporting to keep spreading across repeated blocks

--- a/bin/ai-doctor
+++ b/bin/ai-doctor
@@ -168,6 +168,43 @@ runtime_path_remediation() {
   fi
 }
 
+runtime_status_file() {
+  local label="$1"
+  local raw_path="$2"
+  local trust_vendor="$3"
+  local scope="$4"
+  local status_path=""
+
+  status_path="$(resolve_scope_path "$scope" "$raw_path")"
+  if [[ -f "$status_path" ]]; then
+    printf '  %s: OK %s\n' "$label" "$status_path"
+    return 0
+  fi
+
+  printf '  %s: WARN %s (%s)\n' \
+    "$label" \
+    "$status_path" \
+    "$(runtime_path_remediation "$trust_vendor" "$raw_path")"
+  return 1
+}
+
+runtime_status_directory() {
+  local label="$1"
+  local raw_path="$2"
+  local message="$3"
+  local scope="$4"
+  local status_path=""
+
+  status_path="$(resolve_scope_path "$scope" "$raw_path")"
+  if [[ -d "$status_path" ]]; then
+    printf '  %s: OK %s\n' "$label" "$status_path"
+    return 0
+  fi
+
+  printf '  %s: WARN %s (%s)\n' "$label" "$status_path" "$message"
+  return 1
+}
+
 report_workflow() {
   local workflow_name="$1"
   local default_agent fallback_agents selected_agent="" candidate_name candidate_reason
@@ -235,7 +272,7 @@ report_workflow() {
 
 report_agent() {
   local agent_name="$1"
-  local project_config_path="" user_config_path="" trust_template_path="" mcp_config_path="" project_extensions_path=""
+  local trust_template_path=""
   local agent_status="OK" trust_vendor=""
 
   load_agent_metadata "$agent_name"
@@ -287,48 +324,29 @@ report_agent() {
   fi
 
   if [[ -n "$project_config" ]]; then
-    project_config_path="$(resolve_scope_path project "$project_config")"
-    if [[ -f "$project_config_path" ]]; then
-      printf '  project_config: OK %s\n' "$project_config_path"
-    else
-      printf '  project_config: WARN %s (%s)\n' \
-        "$project_config_path" \
-        "$(runtime_path_remediation "$trust_vendor" "$project_config")"
+    if ! runtime_status_file "project_config" "$project_config" "$trust_vendor" "project"; then
       [[ "$agent_status" == "OK" ]] && agent_status="WARN"
     fi
   fi
 
   if [[ -n "$user_config" ]]; then
-    user_config_path="$(resolve_scope_path user "$user_config")"
-    if [[ -f "$user_config_path" ]]; then
-      printf '  user_config: OK %s\n' "$user_config_path"
-    else
-      printf '  user_config: WARN %s (%s)\n' \
-        "$user_config_path" \
-        "$(runtime_path_remediation "$trust_vendor" "$user_config")"
+    if ! runtime_status_file "user_config" "$user_config" "$trust_vendor" "user"; then
       [[ "$agent_status" == "OK" ]] && agent_status="WARN"
     fi
   fi
 
   if [[ -n "$mcp_config" ]]; then
-    mcp_config_path="$(resolve_scope_path "$(infer_path_scope "$mcp_config")" "$mcp_config")"
-    if [[ -f "$mcp_config_path" ]]; then
-      printf '  mcp_config: OK %s\n' "$mcp_config_path"
-    else
-      printf '  mcp_config: WARN %s (%s)\n' \
-        "$mcp_config_path" \
-        "$(runtime_path_remediation "$trust_vendor" "$mcp_config")"
+    if ! runtime_status_file "mcp_config" "$mcp_config" "$trust_vendor" "$(infer_path_scope "$mcp_config")"; then
       [[ "$agent_status" == "OK" ]] && agent_status="WARN"
     fi
   fi
 
   if [[ -n "$project_extensions" ]]; then
-    project_extensions_path="$(resolve_scope_path project "$project_extensions")"
-    if [[ -d "$project_extensions_path" ]]; then
-      printf '  project_extensions: OK %s\n' "$project_extensions_path"
-    else
-      printf '  project_extensions: WARN %s (create the directory and add vendor-native project extensions if needed)\n' \
-        "$project_extensions_path"
+    if ! runtime_status_directory \
+      "project_extensions" \
+      "$project_extensions" \
+      "create the directory and add vendor-native project extensions if needed" \
+      "project"; then
       [[ "$agent_status" == "OK" ]] && agent_status="WARN"
     fi
   fi

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -717,3 +717,20 @@ Refactor `bin/ai-start` around helper functions for backend validation, stop han
 
 Expected Impact:
 `ai-start` stays behaviorally stable while becoming easier to read, test, and extend if more backends or launch nuances appear later.
+
+## Task 43
+
+Title: Refactor `ai-doctor` runtime status reporting into helpers
+Tracking: #105 (closed)
+
+Problem:
+`ai-doctor` reports project config, user config, MCP config, and project extensions with repeated status-printing blocks. The behavior is consistent today, but the implementation duplicates path resolution and WARN/OK formatting across several cases.
+
+Improvement Idea:
+Keep the current doctor output exactly the same, but move repeated runtime-path reporting into small helpers so agent diagnostics read as a sequence of checks instead of a long set of nearly identical blocks.
+
+Implementation Hint:
+Refactor `bin/ai-doctor` around helpers for file-backed runtime status and directory-backed runtime status. Extend `test/ai_doctor.sh` with at least one extra assertion that protects the filtered or path-specific output during the refactor.
+
+Expected Impact:
+`ai-doctor` becomes easier to maintain and extend without changing the beginner-facing diagnostics or next-step contract.

--- a/tasks/sprint-memory/issue-105.md
+++ b/tasks/sprint-memory/issue-105.md
@@ -1,0 +1,65 @@
+# Sprint
+
+- issue: `#105`
+- branch: `chore/105-ai-doctor-runtime-helpers`
+- date: `2026-03-12`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: refactor `ai-doctor` runtime status reporting into clearer helpers without changing behavior
+- decisions:
+  - keep project_config, user_config, mcp_config, and project_extensions output unchanged
+  - split file-backed and directory-backed runtime status reporting into dedicated helpers
+  - add one extra filtered-output assertion so the refactor is not protected only by broad coverage
+  - keep the sprint local to `bin/ai-doctor` and `test/ai_doctor.sh`
+- constraints:
+  - do not change next-step wording or doctor exit behavior
+  - do not broaden the sprint into docs or new diagnostics
+  - keep shell-level maintenance straightforward
+- current state: `ai-doctor` now routes repeated runtime-status checks through helpers, and tests protect filtered agent output more explicitly
+- next likely moves: either continue shell cleanup in another bounded slice or declare the current polish phase sufficient
+- open questions: whether future cleanup should also reduce global side effects inside `report_workflow` / `report_agent`
+
+## Lane Notes
+
+- Product / Backlog: turned the ai-doctor cleanup opportunity into Task 43 and issue `#105`
+- Delivery / Scrum: kept the sprint to one shell script plus one targeted doctor assertion
+- Implementer: updating `bin/ai-doctor` and `test/ai_doctor.sh`
+- Reviewer / QA: main risk is accidentally changing doctor output formatting while collapsing repeated blocks
+
+## Retrospective Output
+
+- keep
+  - switching to narrow code-cleanliness slices once outward contract work settles
+- change
+  - add a targeted assertion whenever shell diagnostics are rearranged
+- stop
+  - letting repeated runtime-status logic stay duplicated once it becomes obviously patterned
+- follow-ups
+  - consider whether `report_workflow` / `report_agent` global-state coupling should be reduced in a later cleanup sprint
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: not needed
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-doctor`
+  - `test/ai_doctor.sh`
+- rerun commands:
+  - `bash test/ai_doctor.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - runtime status helper extraction must not alter doctor wording, ordering, or exit behavior

--- a/test/ai_doctor.sh
+++ b/test/ai_doctor.sh
@@ -216,6 +216,7 @@ filtered_output="$(
 [[ "$filtered_output" == *"workflow: native"* ]] || fail "filtered ai-doctor output did not include the selected workflow"
 [[ "$filtered_output" == *"agent: local_reviewer"* ]] || fail "filtered ai-doctor output did not include the selected agent"
 [[ "$filtered_output" != *"workflow: unusable"* ]] || fail "filtered ai-doctor output included unrelated workflows"
+[[ "$filtered_output" != *"agent: claude_native"* ]] || fail "filtered ai-doctor output included unrelated agents"
 
 doctor_failure="$(
   cd "$TEST_REPO"


### PR DESCRIPTION
## Summary
- refactor `ai-doctor` runtime file/directory status reporting into dedicated helpers
- keep the current diagnostics and next-step contract stable while reducing repeated blocks
- add targeted filtered-output coverage and record the sprint closeout

## Testing
- bash test/ai_doctor.sh
- make lint
- make test

Closes #105
