### PR TITLE
chore: refactor ai dispatch helpers

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #107 `chore: refactor ai-init starter readme helpers`
-- Branch: `chore/107-ai-init-readme-helpers`
-- Memory Artifact: `tasks/sprint-memory/issue-107.md`
-- Resume Point: ai-init now builds the starter README through section helpers; next sprint can keep tightening shell internals or move into expansion work
+- Active issue: #109 `chore: refactor top-level ai dispatch helpers`
+- Branch: `chore/109-ai-dispatch-helpers`
+- Memory Artifact: `tasks/sprint-memory/issue-109.md`
+- Resume Point: top-level ai dispatch now routes through direct-command, workflow-alias, and unknown-command helpers; next sprint can keep tightening shell internals or move into expansion work
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Refactor `ai-init` starter README generation so the code stays easy to read and extend without changing the current generated output contract.
+Refactor the top-level `ai` entrypoint so the code stays easy to read and extend without changing the current command behavior contract.
 
 ## Working Agreement
 
@@ -33,16 +33,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - cleaner `ai-init` starter README generation
+  - cleaner top-level `ai` dispatch flow
   - concrete surfaces
-  - [`bin/ai-init`](./bin/ai-init)
+  - [`bin/ai`](./bin/ai)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_init.sh`](./test/ai_init.sh)
+  - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - acceptance slice
-  - `ai-init` keeps current starter README output unchanged across current flag variants
-  - repeated README section generation moves into clearer helpers
-  - tests lock the refactor with an explicit section-duplication assertion
+  - top-level `ai` keeps current direct command and workflow alias behavior unchanged
+  - direct dispatch, workflow alias dispatch, and unknown-command recovery move into clearer helpers
+  - tests lock the refactor with an explicit unknown-command assertion
 
 ## Squad
 
@@ -56,30 +56,30 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#107` is the sprint slice for this turn
+  - issue `#109` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 44 was added and converted into issue `#107`
+  - Task 45 was added and converted into issue `#109`
 - Review / Demo
-  - show `bin/ai-init` reading as helper-based README assembly while keeping the same generated starter output
+  - show `bin/ai` reading as helper-based command resolution while keeping the same direct commands and unknown-command behavior
 - Retrospective
   - keep shell cleanup moving once user-facing contracts settle
 
 ## Verification
 
-- `bash test/ai_init.sh`
+- `bash test/ai_cli.sh`
 - `make lint`
 - `make test`
 
 ## Closeout
 
 - Review / Demo
-  - refactor `ai-init` starter README generation into helpers without changing generated output
-  - keep the no-hosted and no-github-actions variants stable
-  - lock the refactor with ai-init tests, including section-duplication coverage
+  - refactor top-level `ai` dispatch into helpers without changing direct-command or workflow-alias behavior
+  - keep unknown-command recovery stable
+  - lock the refactor with CLI tests, including explicit unknown-command coverage
 - Retrospective
   - keep: use small refactors once product wording has stabilized
-  - change: add one explicit duplication guard whenever a long generated document is restructured
-  - stop: letting generated README variants keep duplicating section blocks inline
+  - change: add one explicit recovery-path assertion whenever entrypoint dispatch is rearranged
+  - stop: letting top-level command routing keep growing inline
 - System Updates
   - backlog: updated
   - plans: updated
@@ -91,8 +91,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - cleaning shell-generated document assembly once outward behavior is stable
+  - cleaning shell entrypoints once outward behavior is stable
 - change
-  - lock refactors with a targeted duplication assertion instead of relying only on broad coverage
+  - lock refactors with a targeted recovery assertion instead of relying only on broad coverage
 - stop
-  - allowing generated README section logic to keep spreading across repeated blocks
+  - allowing top-level command dispatch to keep spreading across one case block

--- a/bin/ai
+++ b/bin/ai
@@ -69,6 +69,91 @@ render_workflow_help() {
   done < <(ai_section_keys "$WORKFLOWS_FILE" workflows)
 }
 
+run_direct_command() {
+  local command_name="$1"
+  shift || true
+
+  case "$command_name" in
+    start)
+      exec "$BIN_DIR/ai-start" "$@"
+      ;;
+    stop)
+      exec "$BIN_DIR/ai-start" --stop "$@"
+      ;;
+    init)
+      exec "$BIN_DIR/ai-init" "$@"
+      ;;
+    agents)
+      exec "$BIN_DIR/ai-agent" --list "$@"
+      ;;
+    workflows)
+      exec "$BIN_DIR/ai-agent" --list-workflows "$@"
+      ;;
+    agent)
+      exec "$BIN_DIR/ai-agent" "$@"
+      ;;
+    context)
+      exec "$BIN_DIR/ai-context" "$@"
+      ;;
+    doctor)
+      exec "$BIN_DIR/ai-doctor" "$@"
+      ;;
+    task)
+      exec "$BIN_DIR/ai-task" "$@"
+      ;;
+    code)
+      exec "$BIN_DIR/ai-agent" --workflow code "$@"
+      ;;
+    review)
+      exec "$BIN_DIR/ai-agent" --workflow review "$@"
+      ;;
+    eval)
+      exec "$BIN_DIR/ai-eval" "$@"
+      ;;
+    trust)
+      exec "$BIN_DIR/ai-trust" "$@"
+      ;;
+    install)
+      exec "$BIN_DIR/ai-install" "$@"
+      ;;
+    copy)
+      exec "$BIN_DIR/ai-copy" "$@"
+      ;;
+    open)
+      exec "$BIN_DIR/ai-open" "$@"
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+run_workflow_alias() {
+  local workflow_name="$1"
+  shift || true
+
+  if [[ -f "$WORKFLOWS_FILE" ]] && ai_has_named_key "$WORKFLOWS_FILE" workflows "$workflow_name"; then
+    exec "$BIN_DIR/ai-agent" --workflow "$workflow_name" "$@"
+  fi
+
+  return 1
+}
+
+print_unknown_command() {
+  local command_name="$1"
+
+  echo "unknown ai command: $command_name" >&2
+  echo "run \`ai doctor\` to diagnose repo/runtime readiness first" >&2
+  echo "run \`ai workflows\` to see available workflow aliases and descriptions" >&2
+  echo "repo-local overrides may add commands via .ai-dev-os/workflows.yml" >&2
+  usage >&2
+  exit 2
+}
+
 command_name="${1:-}"
 if [[ -z "$command_name" ]]; then
   usage
@@ -76,67 +161,6 @@ if [[ -z "$command_name" ]]; then
 fi
 shift || true
 
-case "$command_name" in
-  start)
-    exec "$BIN_DIR/ai-start" "$@"
-    ;;
-  stop)
-    exec "$BIN_DIR/ai-start" --stop "$@"
-    ;;
-  init)
-    exec "$BIN_DIR/ai-init" "$@"
-    ;;
-  agents)
-    exec "$BIN_DIR/ai-agent" --list "$@"
-    ;;
-  workflows)
-    exec "$BIN_DIR/ai-agent" --list-workflows "$@"
-    ;;
-  agent)
-    exec "$BIN_DIR/ai-agent" "$@"
-    ;;
-  context)
-    exec "$BIN_DIR/ai-context" "$@"
-    ;;
-  doctor)
-    exec "$BIN_DIR/ai-doctor" "$@"
-    ;;
-  task)
-    exec "$BIN_DIR/ai-task" "$@"
-    ;;
-  code)
-    exec "$BIN_DIR/ai-agent" --workflow code "$@"
-    ;;
-  review)
-    exec "$BIN_DIR/ai-agent" --workflow review "$@"
-    ;;
-  eval)
-    exec "$BIN_DIR/ai-eval" "$@"
-    ;;
-  trust)
-    exec "$BIN_DIR/ai-trust" "$@"
-    ;;
-  install)
-    exec "$BIN_DIR/ai-install" "$@"
-    ;;
-  copy)
-    exec "$BIN_DIR/ai-copy" "$@"
-    ;;
-  open)
-    exec "$BIN_DIR/ai-open" "$@"
-    ;;
-  -h|--help|help)
-    usage
-    ;;
-  *)
-    if [[ -f "$WORKFLOWS_FILE" ]] && ai_has_named_key "$WORKFLOWS_FILE" workflows "$command_name"; then
-      exec "$BIN_DIR/ai-agent" --workflow "$command_name" "$@"
-    fi
-    echo "unknown ai command: $command_name" >&2
-    echo "run \`ai doctor\` to diagnose repo/runtime readiness first" >&2
-    echo "run \`ai workflows\` to see available workflow aliases and descriptions" >&2
-    echo "repo-local overrides may add commands via .ai-dev-os/workflows.yml" >&2
-    usage >&2
-    exit 2
-    ;;
-esac
+run_direct_command "$command_name" "$@" || true
+run_workflow_alias "$command_name" "$@" || true
+print_unknown_command "$command_name"

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -751,3 +751,20 @@ Refactor `bin/ai-init` around helper functions for repeated README sections and 
 
 Expected Impact:
 Starter README generation stays behaviorally stable while becoming easier to maintain when onboarding wording evolves.
+
+## Task 45
+
+Title: Refactor top-level `ai` command dispatch into helpers
+Tracking: #109 (closed)
+
+Problem:
+The top-level `ai` wrapper now mixes help rendering, workflow shortcut rendering, direct command dispatch, workflow alias dispatch, and unknown-command recovery in one linear case block. The behavior is still stable, but the control flow is harder to scan than it needs to be.
+
+Improvement Idea:
+Keep the current `ai` behavior exactly the same, but extract direct dispatch and unknown-command recovery into small helpers so the top-level flow reads as command resolution instead of a long monolithic case.
+
+Implementation Hint:
+Refactor `bin/ai` around helper functions for direct command execution, workflow alias execution, and unknown-command recovery. Extend `test/ai_cli.sh` with a targeted assertion for the unknown-command path so the refactor keeps stderr guidance and exit status stable.
+
+Expected Impact:
+The `ai` entrypoint remains behaviorally stable while becoming easier to maintain as the command surface grows.

--- a/tasks/sprint-memory/issue-109.md
+++ b/tasks/sprint-memory/issue-109.md
@@ -1,0 +1,65 @@
+# Sprint
+
+- issue: `#109`
+- branch: `chore/109-ai-dispatch-helpers`
+- date: `2026-03-12`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: refactor top-level `ai` command dispatch into clearer helpers without changing behavior
+- decisions:
+  - keep direct command routing, workflow alias routing, and unknown-command recovery unchanged
+  - split direct dispatch, workflow alias dispatch, and unknown-command recovery into dedicated helpers
+  - add one explicit unknown-command assertion so the refactor is not protected only by broad CLI coverage
+  - keep the sprint local to `bin/ai` and `test/ai_cli.sh`
+- constraints:
+  - do not change help wording or workflow alias behavior
+  - do not broaden the sprint into ai-agent or ai-doctor
+  - keep the top-level flow simple enough for shell maintenance
+- current state: `bin/ai` now reads as helper-based command resolution, and CLI tests protect the unknown-command stderr contract more explicitly
+- next likely moves: either keep refactoring shell entrypoints in small slices or shift attention to new capabilities
+- open questions: whether `ai-agent` should be the next target because it now carries the heaviest remaining output/dispatch logic
+
+## Lane Notes
+
+- Product / Backlog: turned the top-level ai cleanup opportunity into Task 45 and issue `#109`
+- Delivery / Scrum: kept the sprint to one shell entrypoint plus one targeted CLI assertion
+- Implementer: updating `bin/ai` and `test/ai_cli.sh`
+- Reviewer / QA: main risk is accidentally changing unknown-command behavior or workflow alias resolution while splitting helpers
+
+## Retrospective Output
+
+- keep
+  - switching to narrow code-cleanliness slices once outward contract work settles
+- change
+  - add a targeted recovery-path assertion whenever entrypoint dispatch is rearranged
+- stop
+  - letting top-level command routing keep growing inline
+- follow-ups
+  - consider whether `ai-agent` should be the next shell cleanup target
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: not needed
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - helper extraction must not alter unknown-command stderr guidance or workflow alias execution

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -428,6 +428,14 @@ review_fallback_output="$(
 assert_contains "$CLAUDE_LOG" "claude --append-system-prompt Workflow prompt"
 assert_contains "$CLAUDE_LOG" "--fallback-check"
 assert_contains "$CLAUDE_LOG" "source: $REPO/prompts/implementer.md"
+
+unknown_ai_output="$(
+  PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" not-a-command 2>&1 >/dev/null || true
+)"
+[[ "$unknown_ai_output" == *"unknown ai command: not-a-command"* ]] || fail "ai did not keep the unknown-command error"
+[[ "$unknown_ai_output" == *"run \`ai doctor\` to diagnose repo/runtime readiness first"* ]] || fail "ai did not keep doctor-first unknown-command guidance"
+[[ "$unknown_ai_output" == *"run \`ai workflows\` to see available workflow aliases and descriptions"* ]] || fail "ai did not keep workflow discovery guidance on unknown command"
+[[ "$unknown_ai_output" == *"usage: ai <command> [args...]"* ]] || fail "ai did not keep usage in the unknown-command output"
 cat > "$STUB_BIN/codex" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary
- refactor top-level `ai` command resolution into direct-command, workflow-alias, and recovery helpers
- keep current help and dispatch behavior stable while reducing inline routing logic
- add explicit unknown-command coverage and record the sprint closeout

## Testing
- bash test/ai_cli.sh
- make lint
- make test

Closes #109
