### PR TITLE
chore: refactor ai-agent resolution helpers

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #109 `chore: refactor top-level ai dispatch helpers`
-- Branch: `chore/109-ai-dispatch-helpers`
-- Memory Artifact: `tasks/sprint-memory/issue-109.md`
-- Resume Point: top-level ai dispatch now routes through direct-command, workflow-alias, and unknown-command helpers; next sprint can keep tightening shell internals or move into expansion work
+- Active issue: #111 `chore: refactor ai-agent resolution helpers`
+- Branch: `chore/111-ai-agent-resolution-helpers`
+- Memory Artifact: `tasks/sprint-memory/issue-111.md`
+- Resume Point: ai-agent now routes config-path output, candidate resolution, and describe/recovery paths through helpers; next sprint can keep tightening shell internals or move into expansion work
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Refactor the top-level `ai` entrypoint so the code stays easy to read and extend without changing the current command behavior contract.
+Refactor `ai-agent` resolution and describe flows so the code stays easy to read and extend without changing the current workflow routing and recovery contracts.
 
 ## Working Agreement
 
@@ -33,16 +33,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - cleaner top-level `ai` dispatch flow
+  - cleaner `ai-agent` resolution and describe flow
   - concrete surfaces
-  - [`bin/ai`](./bin/ai)
+  - [`bin/ai-agent`](./bin/ai-agent)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
   - [`test/ai_cli.sh`](./test/ai_cli.sh)
   - acceptance slice
-  - top-level `ai` keeps current direct command and workflow alias behavior unchanged
-  - direct dispatch, workflow alias dispatch, and unknown-command recovery move into clearer helpers
-  - tests lock the refactor with an explicit unknown-command assertion
+  - `ai-agent` keeps current list, describe, workflow resolution, and launch behavior unchanged
+  - config-path output, candidate resolution, and describe/recovery logic move into clearer helpers
+  - tests lock the refactor with an explicit unknown-workflow recovery assertion
 
 ## Squad
 
@@ -56,11 +56,11 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#109` is the sprint slice for this turn
+  - issue `#111` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 45 was added and converted into issue `#109`
+  - Task 46 was added and converted into issue `#111`
 - Review / Demo
-  - show `bin/ai` reading as helper-based command resolution while keeping the same direct commands and unknown-command behavior
+  - show `bin/ai-agent` reading as helper-based resolution while keeping the same describe and recovery behavior
 - Retrospective
   - keep shell cleanup moving once user-facing contracts settle
 
@@ -73,13 +73,13 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Closeout
 
 - Review / Demo
-  - refactor top-level `ai` dispatch into helpers without changing direct-command or workflow-alias behavior
-  - keep unknown-command recovery stable
-  - lock the refactor with CLI tests, including explicit unknown-command coverage
+  - refactor `ai-agent` resolution and describe flows into helpers without changing routing behavior
+  - keep unknown-workflow and unknown-agent recovery stable
+  - lock the refactor with CLI tests, including explicit unknown-workflow coverage
 - Retrospective
   - keep: use small refactors once product wording has stabilized
-  - change: add one explicit recovery-path assertion whenever entrypoint dispatch is rearranged
-  - stop: letting top-level command routing keep growing inline
+  - change: add one explicit recovery-path assertion whenever resolution logic is rearranged
+  - stop: letting `ai-agent` keep accumulating one long staged control path
 - System Updates
   - backlog: updated
   - plans: updated
@@ -91,8 +91,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - cleaning shell entrypoints once outward behavior is stable
+  - cleaning heavy shell resolution surfaces once outward behavior is stable
 - change
   - lock refactors with a targeted recovery assertion instead of relying only on broad coverage
 - stop
-  - allowing top-level command dispatch to keep spreading across one case block
+  - allowing ai-agent resolution, describe, and recovery logic to keep spreading across one control path

--- a/bin/ai-agent
+++ b/bin/ai-agent
@@ -253,6 +253,104 @@ list_workflows() {
   printf '  - then continue the beginner path: ai start\n'
 }
 
+print_config_path() {
+  local config_kind="$1"
+
+  case "$config_kind" in
+    agents)
+      printf '%s\n' "$AGENTS_FILE"
+      ;;
+    workflows)
+      printf '%s\n' "$WORKFLOWS_FILE"
+      ;;
+    *)
+      echo "unknown config kind: $config_kind" >&2
+      exit 2
+      ;;
+  esac
+}
+
+print_unknown_workflow() {
+  local workflow_name="$1"
+
+  echo "unknown workflow: $workflow_name" >&2
+  echo "run \`ai workflows\` to inspect available workflow names and descriptions" >&2
+  exit 2
+}
+
+print_unknown_agent() {
+  local agent_name="$1"
+
+  echo "unknown agent: $agent_name" >&2
+  echo "run \`ai agents\` to inspect configured agents and their roles" >&2
+  exit 2
+}
+
+append_unique_candidate() {
+  local candidate_name="$1"
+  local existing_candidate
+
+  [[ -n "$candidate_name" ]] || return 0
+  if [[ -n "${resolution_candidates[*]-}" ]]; then
+    for existing_candidate in "${resolution_candidates[@]}"; do
+      [[ "$existing_candidate" == "$candidate_name" ]] && return 0
+    done
+  fi
+
+  resolution_candidates+=("$candidate_name")
+}
+
+resolve_candidates() {
+  local candidate_name
+
+  resolution_candidates=()
+  if [[ -n "$workflow_name" ]]; then
+    while IFS= read -r candidate_name; do
+      append_unique_candidate "$candidate_name"
+    done < <(ai_workflow_candidate_agents "$WORKFLOWS_FILE" "$workflow_name")
+  else
+    resolution_candidates=("$agent_name")
+  fi
+
+  if [[ -z "${resolution_candidates[*]-}" ]]; then
+    print_unknown_workflow "$workflow_name"
+  fi
+}
+
+print_describe_output() {
+  if [[ -z "$command_name" ]]; then
+    print_unknown_agent "$agent_name"
+  fi
+
+  printf 'agent: %s\n' "$agent_name"
+  if [[ -n "$workflow_name" ]]; then
+    printf 'workflow: %s\n' "$workflow_name"
+    if [[ -n "$fallback_agents_raw" ]]; then
+      printf 'fallback_agents: %s\n' "$fallback_agents_raw"
+    fi
+    printf 'resolution_candidates: %s\n' "$(join_with ", " "${resolution_candidates[@]}")"
+  fi
+  [[ -n "$description" ]] && printf 'description: %s\n' "$description"
+  printf 'command: %s\n' "$command_name"
+  printf 'role: %s\n' "${role_name:-unknown}"
+  [[ -n "$provider_name" ]] && printf 'provider: %s\n' "$provider_name"
+  [[ -n "$automation_mode" ]] && printf 'automation_mode: %s\n' "$automation_mode"
+  [[ -n "$docs_url" ]] && printf 'docs_url: %s\n' "$docs_url"
+  [[ -n "$user_config" ]] && printf 'user_config: %s\n' "$user_config"
+  [[ -n "$project_config" ]] && printf 'project_config: %s\n' "$project_config"
+  [[ -n "$project_extensions" ]] && printf 'project_extensions: %s\n' "$project_extensions"
+  [[ -n "$mcp_config" ]] && printf 'mcp_config: %s\n' "$mcp_config"
+  printf 'launch_behavior: %s\n' "$(describe_launch_behavior "$prompt_handoff" "$context_handoff")"
+  [[ -n "$prompt_file" ]] && printf 'prompt_file: %s\n' "$prompt_file"
+  [[ -n "$candidate_prompt_file" ]] && printf 'resolved_prompt_file: %s\n' "$candidate_prompt_file"
+  [[ -n "$prompt_handoff" ]] && printf 'prompt_handoff: %s\n' "$prompt_handoff"
+  [[ -n "$context_handoff" ]] && printf 'context_handoff: %s\n' "$context_handoff"
+  [[ -n "$context_handoff" ]] && printf 'resolved_context_file: %s\n' "$context_file"
+  [[ -n "$trust_template" ]] && printf 'trust_template: %s\n' "$trust_template"
+  printf 'agents_config: %s\n' "$AGENTS_FILE"
+  printf 'workflows_config: %s\n' "$WORKFLOWS_FILE"
+}
+
 config_kind=""
 action="run"
 workflow_name=""
@@ -324,18 +422,7 @@ case "$action" in
     exit 0
     ;;
   config_path)
-    case "$config_kind" in
-      agents)
-        printf '%s\n' "$AGENTS_FILE"
-        ;;
-      workflows)
-        printf '%s\n' "$WORKFLOWS_FILE"
-        ;;
-      *)
-        echo "unknown config kind: $config_kind" >&2
-        exit 2
-        ;;
-    esac
+    print_config_path "$config_kind"
     exit 0
     ;;
 esac
@@ -344,9 +431,7 @@ if [[ -n "$workflow_name" ]]; then
   agent_name="$(ai_config_value "$WORKFLOWS_FILE" "workflows" "$workflow_name" "default_agent")"
   fallback_agents_raw="$(ai_config_value "$WORKFLOWS_FILE" "workflows" "$workflow_name" "fallback_agents")"
   if [[ -z "$agent_name" ]]; then
-    echo "unknown workflow: $workflow_name" >&2
-    echo "run \`ai workflows\` to inspect available workflow names and descriptions" >&2
-    exit 2
+    print_unknown_workflow "$workflow_name"
   fi
 elif [[ -z "$agent_name" ]]; then
   usage
@@ -357,66 +442,13 @@ declare -a resolution_candidates=()
 declare -a candidate_failures=()
 selected_agent_name=""
 
-if [[ -n "$workflow_name" ]]; then
-  while IFS= read -r candidate_name; do
-    local_duplicate=0
-    [[ -n "$candidate_name" ]] || continue
-    if [[ -n "${resolution_candidates[*]-}" ]]; then
-      for existing_candidate in "${resolution_candidates[@]}"; do
-        if [[ "$existing_candidate" == "$candidate_name" ]]; then
-          local_duplicate=1
-          break
-        fi
-      done
-    fi
-    [[ $local_duplicate -eq 0 ]] && resolution_candidates+=("$candidate_name")
-  done < <(ai_workflow_candidate_agents "$WORKFLOWS_FILE" "$workflow_name")
-else
-  resolution_candidates=("$agent_name")
-fi
-
-if [[ -z "${resolution_candidates[*]-}" ]]; then
-  echo "unknown workflow: $workflow_name" >&2
-  echo "run \`ai workflows\` to inspect available workflow names and descriptions" >&2
-  exit 2
-fi
+resolve_candidates
 
 agent_name="${resolution_candidates[0]}"
 load_agent_metadata "$agent_name"
 
 if [[ "$action" == "describe" ]]; then
-  if [[ -z "$command_name" ]]; then
-    echo "unknown agent: $agent_name" >&2
-    echo "run \`ai agents\` to inspect configured agents and their roles" >&2
-    exit 2
-  fi
-  printf 'agent: %s\n' "$agent_name"
-  if [[ -n "$workflow_name" ]]; then
-    printf 'workflow: %s\n' "$workflow_name"
-    if [[ -n "$fallback_agents_raw" ]]; then
-      printf 'fallback_agents: %s\n' "$fallback_agents_raw"
-    fi
-    printf 'resolution_candidates: %s\n' "$(join_with ", " "${resolution_candidates[@]}")"
-  fi
-  [[ -n "$description" ]] && printf 'description: %s\n' "$description"
-  printf 'command: %s\n' "$command_name"
-  printf 'role: %s\n' "${role_name:-unknown}"
-  [[ -n "$provider_name" ]] && printf 'provider: %s\n' "$provider_name"
-  [[ -n "$automation_mode" ]] && printf 'automation_mode: %s\n' "$automation_mode"
-  [[ -n "$docs_url" ]] && printf 'docs_url: %s\n' "$docs_url"
-  [[ -n "$user_config" ]] && printf 'user_config: %s\n' "$user_config"
-  [[ -n "$project_config" ]] && printf 'project_config: %s\n' "$project_config"
-  [[ -n "$project_extensions" ]] && printf 'project_extensions: %s\n' "$project_extensions"
-  [[ -n "$mcp_config" ]] && printf 'mcp_config: %s\n' "$mcp_config"
-  printf 'launch_behavior: %s\n' "$(describe_launch_behavior "$prompt_handoff" "$context_handoff")"
-  [[ -n "$prompt_file" ]] && printf 'prompt_file: %s\n' "$prompt_file"
-  [[ -n "$candidate_prompt_file" ]] && printf 'resolved_prompt_file: %s\n' "$candidate_prompt_file"
-  [[ -n "$prompt_handoff" ]] && printf 'prompt_handoff: %s\n' "$prompt_handoff"
-  [[ -n "$context_handoff" ]] && printf 'context_handoff: %s\n' "$context_handoff"
-  [[ -n "$context_handoff" ]] && printf 'resolved_context_file: %s\n' "$context_file"
-  [[ -n "$trust_template" ]] && printf 'trust_template: %s\n' "$trust_template"
-  printf 'agents_config: %s\n' "$AGENTS_FILE"
-  printf 'workflows_config: %s\n' "$WORKFLOWS_FILE"
+  print_describe_output
   exit 0
 fi
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -768,3 +768,20 @@ Refactor `bin/ai` around helper functions for direct command execution, workflow
 
 Expected Impact:
 The `ai` entrypoint remains behaviorally stable while becoming easier to maintain as the command surface grows.
+
+## Task 46
+
+Title: Refactor `ai-agent` resolution and describe flows into helpers
+Tracking: pending
+
+Problem:
+`ai-agent` now mixes option parsing, workflow candidate resolution, describe output, remediation output, and final launch handoff in one long control path. The behavior is stable, but the script has become the heaviest remaining shell surface and is harder to evolve safely.
+
+Improvement Idea:
+Keep current `ai-agent` behavior exactly the same, but split workflow resolution, describe rendering, and recovery/reporting into helpers so the script reads as staged resolution instead of one large body.
+
+Implementation Hint:
+Refactor `bin/ai-agent` around helpers for config-path output, candidate deduplication/resolution, describe rendering, and unknown-workflow/agent reporting. Extend `test/ai_cli.sh` with at least one explicit recovery-path assertion for `ai-agent`.
+
+Expected Impact:
+`ai-agent` remains behaviorally stable while becoming easier to maintain, review, and extend as workflow routing grows.

--- a/tasks/sprint-memory/issue-111.md
+++ b/tasks/sprint-memory/issue-111.md
@@ -1,0 +1,65 @@
+# Sprint
+
+- issue: `#111`
+- branch: `chore/111-ai-agent-resolution-helpers`
+- date: `2026-03-12`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: refactor `ai-agent` resolution and describe flows into clearer helpers without changing behavior
+- decisions:
+  - keep config-path output, workflow candidate resolution, describe output, and recovery stderr unchanged
+  - split config-path printing, unknown workflow/agent reporting, candidate deduplication, and describe rendering into dedicated helpers
+  - add one explicit unknown-workflow assertion so the refactor is not protected only by broad CLI coverage
+  - keep the sprint local to `bin/ai-agent` and `test/ai_cli.sh`
+- constraints:
+  - do not change launch handoff semantics
+  - do not broaden the sprint into new workflow features
+  - keep helper extraction understandable for shell maintenance
+- current state: `ai-agent` now reads more like staged resolution over helpers, and CLI tests protect unknown-workflow recovery more explicitly
+- next likely moves: either continue shell cleanup in another bounded slice or move to feature expansion
+- open questions: whether `ai-doctor` global-state reduction is the next highest-value cleanup once `ai-agent` is no longer the heaviest script
+
+## Lane Notes
+
+- Product / Backlog: turned the ai-agent cleanup opportunity into Task 46 and issue `#111`
+- Delivery / Scrum: kept the sprint to one heavy shell surface plus one targeted CLI assertion
+- Implementer: updating `bin/ai-agent` and `test/ai_cli.sh`
+- Reviewer / QA: main risk is accidentally changing describe output or unknown-workflow recovery while splitting helpers
+
+## Retrospective Output
+
+- keep
+  - switching to bounded refactor bundles instead of one tiny issue at a time
+- change
+  - add a targeted recovery assertion whenever shell resolution logic is rearranged
+- stop
+  - letting the heaviest remaining shell surface stay monolithic once its contracts are stable
+- follow-ups
+  - consider `ai-doctor` global-state reduction as the next cleanup target
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: not needed
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-agent`
+  - `test/ai_cli.sh`
+- rerun commands:
+  - `bash test/ai_cli.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - helper extraction must not alter describe output ordering or recovery stderr guidance

--- a/test/ai_cli.sh
+++ b/test/ai_cli.sh
@@ -336,6 +336,12 @@ workflow_describe_output="$(cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$R
 [[ "$workflow_describe_output" == *"resolution_candidates: reviewer, claude, gemini"* ]] || fail "ai-agent describe missing resolution candidates"
 [[ "$workflow_describe_output" == *"agents_config: $REPO/ai/agents.yml"* ]] || fail "ai-agent did not report the resolved agent config"
 
+unknown_workflow_describe_output="$(
+  cd "$GLOBAL_REPO" && PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-agent" --describe --workflow missing 2>&1 >/dev/null || true
+)"
+[[ "$unknown_workflow_describe_output" == *"unknown workflow: missing"* ]] || fail "ai-agent did not keep the unknown-workflow error"
+[[ "$unknown_workflow_describe_output" == *"run \`ai workflows\` to inspect available workflow names and descriptions"* ]] || fail "ai-agent did not keep workflow recovery guidance for unknown workflow"
+
 task_output="$(cd "$GLOBAL_REPO" && AI_TASK_BACKLOG_FILE="$PENDING_BACKLOG" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai" task)"
 [[ "$task_output" == *"AI Dev OS Pending Tasks"* ]] || fail "ai task did not print the pending summary header"
 [[ "$task_output" == *"Pending count: 1"* ]] || fail "ai task did not print the pending task count"


### PR DESCRIPTION
## Summary
- refactor `ai-agent` config-path, candidate resolution, describe, and recovery flows into helpers
- keep current workflow routing and launch handoff behavior stable while reducing monolithic control flow
- add explicit unknown-workflow coverage and record the sprint closeout

## Testing
- bash test/ai_cli.sh
- make lint
- make test

Closes #111
