### PR TITLE
chore: refactor ai-doctor control helpers

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -3,10 +3,10 @@
 - Date: 2026-03-11
 - Sprint Status: `closed`
 - Sprint Scope: `turn-scoped`
-- Active issue: #111 `chore: refactor ai-agent resolution helpers`
-- Branch: `chore/111-ai-agent-resolution-helpers`
-- Memory Artifact: `tasks/sprint-memory/issue-111.md`
-- Resume Point: ai-agent now routes config-path output, candidate resolution, and describe/recovery paths through helpers; next sprint can keep tightening shell internals or move into expansion work
+- Active issue: #113 `chore: refactor ai-doctor control flow helpers`
+- Branch: `chore/113-ai-doctor-control-helpers`
+- Memory Artifact: `tasks/sprint-memory/issue-113.md`
+- Resume Point: ai-doctor now routes filter validation, section printing, and warn/fail bookkeeping through helpers; next sprint can keep tightening shell internals or move into expansion work
 
 ## North Star
 
@@ -19,7 +19,7 @@
 
 ## Current Goal
 
-Refactor `ai-agent` resolution and describe flows so the code stays easy to read and extend without changing the current workflow routing and recovery contracts.
+Refactor `ai-doctor` control flow so the code stays easy to read and extend without changing the current reporting and next-step contracts.
 
 ## Working Agreement
 
@@ -33,16 +33,16 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Sprint Slice
 
   - primary deliverable
-  - cleaner `ai-agent` resolution and describe flow
+  - cleaner `ai-doctor` reporting control flow
   - concrete surfaces
-  - [`bin/ai-agent`](./bin/ai-agent)
+  - [`bin/ai-doctor`](./bin/ai-doctor)
   - [`tasks/backlog.md`](./tasks/backlog.md)
   - [`PLANS.md`](./PLANS.md)
-  - [`test/ai_cli.sh`](./test/ai_cli.sh)
+  - [`test/ai_doctor.sh`](./test/ai_doctor.sh)
   - acceptance slice
-  - `ai-agent` keeps current list, describe, workflow resolution, and launch behavior unchanged
-  - config-path output, candidate resolution, and describe/recovery logic move into clearer helpers
-  - tests lock the refactor with an explicit unknown-workflow recovery assertion
+  - `ai-doctor` keeps current reporting and next-step behavior unchanged
+  - filter validation, section printing, and warn/fail bookkeeping move into clearer helpers
+  - tests lock the refactor with an explicit unknown-workflow assertion
 
 ## Squad
 
@@ -56,30 +56,31 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Current Sprint Ceremonies
 
 - Sprint Planning
-  - issue `#111` is the sprint slice for this turn
+  - issue `#113` is the sprint slice for this turn
 - Backlog Refinement
-  - Task 46 was added and converted into issue `#111`
+  - Task 47 was added and converted into issue `#113`
 - Review / Demo
-  - show `bin/ai-agent` reading as helper-based resolution while keeping the same describe and recovery behavior
+  - show `bin/ai-doctor` reading as helper-based reporting flow while keeping the same diagnostics and next steps
 - Retrospective
   - keep shell cleanup moving once user-facing contracts settle
 
 ## Verification
 
 - `bash test/ai_cli.sh`
+- `bash test/ai_doctor.sh`
 - `make lint`
 - `make test`
 
 ## Closeout
 
 - Review / Demo
-  - refactor `ai-agent` resolution and describe flows into helpers without changing routing behavior
-  - keep unknown-workflow and unknown-agent recovery stable
-  - lock the refactor with CLI tests, including explicit unknown-workflow coverage
+  - refactor `ai-doctor` control flow into helpers without changing reporting behavior
+  - keep unknown-filter recovery and next-step guidance stable
+  - lock the refactor with doctor tests, including explicit unknown-workflow coverage
 - Retrospective
   - keep: use small refactors once product wording has stabilized
-  - change: add one explicit recovery-path assertion whenever resolution logic is rearranged
-  - stop: letting `ai-agent` keep accumulating one long staged control path
+  - change: add one explicit recovery-path assertion whenever report control flow is rearranged
+  - stop: letting ai-doctor keep mixing printing and global-state mutation inline
 - System Updates
   - backlog: updated
   - plans: updated
@@ -91,8 +92,8 @@ Active multi-step work follows [`docs/93-scrum-delivery.md`](./docs/93-scrum-del
 ## Retrospective
 
 - keep
-  - cleaning heavy shell resolution surfaces once outward behavior is stable
+  - cleaning heavy shell reporting surfaces once outward behavior is stable
 - change
   - lock refactors with a targeted recovery assertion instead of relying only on broad coverage
 - stop
-  - allowing ai-agent resolution, describe, and recovery logic to keep spreading across one control path
+  - allowing ai-doctor validation, section printing, and state updates to keep spreading across one control path

--- a/bin/ai-doctor
+++ b/bin/ai-doctor
@@ -43,6 +43,19 @@ join_with() {
   printf '%s\n' "$output"
 }
 
+mark_failure() {
+  overall_exit=1
+}
+
+mark_warning() {
+  any_warn=1
+}
+
+remember_warned_workflow() {
+  local workflow_name="$1"
+  [[ -z "$warned_workflow" ]] && warned_workflow="$workflow_name"
+}
+
 resolve_scope_path() {
   local scope="$1"
   local raw_path="$2"
@@ -205,6 +218,62 @@ runtime_status_directory() {
   return 1
 }
 
+validate_named_filter() {
+  local config_file="$1"
+  local section="$2"
+  local filter_name="$3"
+  local label="$4"
+
+  [[ -z "$filter_name" ]] && return 0
+  if ai_has_named_key "$config_file" "$section" "$filter_name"; then
+    return 0
+  fi
+
+  echo "unknown $label: $filter_name" >&2
+  exit 2
+}
+
+print_doctor_header() {
+  printf 'AI Dev OS doctor\n'
+  printf 'repo: %s\n' "$TARGET_REPO"
+  printf 'agents_config: %s\n' "$AGENTS_FILE"
+  printf 'workflows_config: %s\n' "$WORKFLOWS_FILE"
+  printf '\n'
+}
+
+print_section_header() {
+  local title="$1"
+  printf '%s\n' "$title"
+}
+
+report_requested_workflows() {
+  local workflow_name
+
+  if [[ -n "$workflow_filter" ]]; then
+    report_workflow "$workflow_filter"
+    return
+  fi
+
+  while IFS= read -r workflow_name; do
+    [[ -n "$workflow_name" ]] || continue
+    report_workflow "$workflow_name"
+  done < <(ai_section_keys "$WORKFLOWS_FILE" workflows)
+}
+
+report_requested_agents() {
+  local listed_agent
+
+  if [[ -n "$agent_filter" ]]; then
+    report_agent "$agent_filter"
+    return
+  fi
+
+  while IFS= read -r listed_agent; do
+    [[ -n "$listed_agent" ]] || continue
+    report_agent "$listed_agent"
+  done < <(ai_section_keys "$AGENTS_FILE" agents)
+}
+
 report_workflow() {
   local workflow_name="$1"
   local default_agent fallback_agents selected_agent="" candidate_name candidate_reason
@@ -255,11 +324,11 @@ report_workflow() {
 
   if [[ -z "$selected_agent" ]]; then
     workflow_status="FAIL no available candidates"
-    overall_exit=1
+    mark_failure
   elif [[ "$selected_agent" != "${candidates[0]}" ]]; then
     workflow_status="WARN fallback to $selected_agent"
-    any_warn=1
-    [[ -z "$warned_workflow" ]] && warned_workflow="$workflow_name"
+    mark_warning
+    remember_warned_workflow "$workflow_name"
   fi
 
   printf '  status: %s\n' "$workflow_status"
@@ -287,7 +356,7 @@ report_agent() {
   else
     printf '  dependency: FAIL missing dependency: %s\n' "${command_name:-unknown}"
     agent_status="FAIL"
-    overall_exit=1
+    mark_failure
   fi
 
   if [[ -n "$prompt_file" ]]; then
@@ -296,7 +365,7 @@ report_agent() {
     elif [[ -n "$prompt_handoff" && "$prompt_handoff" != "none" ]]; then
       printf '  prompt_file: FAIL %s\n' "${candidate_prompt_file:-$prompt_file}"
       agent_status="FAIL"
-      overall_exit=1
+      mark_failure
     else
       printf '  prompt_file: INFO %s (handoff disabled)\n' "${candidate_prompt_file:-$prompt_file}"
     fi
@@ -308,7 +377,7 @@ report_agent() {
     else
       printf '  context_summary: FAIL %s\n' "$context_error"
       agent_status="FAIL"
-      overall_exit=1
+      mark_failure
     fi
   fi
 
@@ -319,7 +388,7 @@ report_agent() {
     else
       printf '  trust_template: FAIL %s\n' "$trust_template_path"
       agent_status="FAIL"
-      overall_exit=1
+      mark_failure
     fi
   fi
 
@@ -353,7 +422,7 @@ report_agent() {
 
   [[ -n "$docs_url" ]] && printf '  docs: %s\n' "$docs_url"
   printf '  status: %s\n' "$agent_status"
-  [[ "$agent_status" == "WARN" ]] && any_warn=1
+  [[ "$agent_status" == "WARN" ]] && mark_warning
   printf '\n'
 }
 
@@ -423,41 +492,14 @@ overall_exit=0
 any_warn=0
 warned_workflow=""
 
-if [[ -n "$workflow_filter" ]] && ! ai_has_named_key "$WORKFLOWS_FILE" workflows "$workflow_filter"; then
-  echo "unknown workflow: $workflow_filter" >&2
-  exit 2
-fi
+validate_named_filter "$WORKFLOWS_FILE" "workflows" "$workflow_filter" "workflow"
+validate_named_filter "$AGENTS_FILE" "agents" "$agent_filter" "agent"
 
-if [[ -n "$agent_filter" ]] && ! ai_has_named_key "$AGENTS_FILE" agents "$agent_filter"; then
-  echo "unknown agent: $agent_filter" >&2
-  exit 2
-fi
-
-printf 'AI Dev OS doctor\n'
-printf 'repo: %s\n' "$TARGET_REPO"
-printf 'agents_config: %s\n' "$AGENTS_FILE"
-printf 'workflows_config: %s\n' "$WORKFLOWS_FILE"
-printf '\n'
-
-printf 'Workflow Resolution\n'
-if [[ -n "$workflow_filter" ]]; then
-  report_workflow "$workflow_filter"
-else
-  while IFS= read -r workflow_name; do
-    [[ -n "$workflow_name" ]] || continue
-    report_workflow "$workflow_name"
-  done < <(ai_section_keys "$WORKFLOWS_FILE" workflows)
-fi
-
-printf 'Agent Diagnostics\n'
-if [[ -n "$agent_filter" ]]; then
-  report_agent "$agent_filter"
-else
-  while IFS= read -r listed_agent; do
-    [[ -n "$listed_agent" ]] || continue
-    report_agent "$listed_agent"
-  done < <(ai_section_keys "$AGENTS_FILE" agents)
-fi
+print_doctor_header
+print_section_header "Workflow Resolution"
+report_requested_workflows
+print_section_header "Agent Diagnostics"
+report_requested_agents
 
 print_next_steps
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -785,3 +785,20 @@ Refactor `bin/ai-agent` around helpers for config-path output, candidate dedupli
 
 Expected Impact:
 `ai-agent` remains behaviorally stable while becoming easier to maintain, review, and extend as workflow routing grows.
+
+## Task 47
+
+Title: Refactor `ai-doctor` control flow and state updates into helpers
+Tracking: pending
+
+Problem:
+`ai-doctor` still mixes filter validation, header/section printing, and warn/fail state mutation directly into the main flow and report functions. Runtime status reporting is already cleaner, but the overall control path still leans on scattered global updates.
+
+Improvement Idea:
+Keep current `ai-doctor` behavior exactly the same, but move filter validation, section rendering, and warn/fail state transitions into small helpers so the script reads as staged reporting instead of interleaved output and state mutation.
+
+Implementation Hint:
+Refactor `bin/ai-doctor` around helpers for validation, section printing, and warning/failure bookkeeping. Extend `test/ai_doctor.sh` with at least one explicit unknown-filter assertion so recovery behavior stays pinned during the refactor.
+
+Expected Impact:
+`ai-doctor` remains behaviorally stable while becoming easier to reason about and extend, especially when new diagnostics are added later.

--- a/tasks/sprint-memory/issue-113.md
+++ b/tasks/sprint-memory/issue-113.md
@@ -1,0 +1,65 @@
+# Sprint
+
+- issue: `#113`
+- branch: `chore/113-ai-doctor-control-helpers`
+- date: `2026-03-12`
+- lanes:
+  - Product / Backlog: Codex
+  - Delivery / Scrum: Codex
+  - Implementer: Codex
+  - Reviewer / QA: Codex
+
+## Compressed Memory
+
+- goal: refactor `ai-doctor` control flow and state updates into clearer helpers without changing behavior
+- decisions:
+  - keep workflow/agent reporting and next-step wording unchanged
+  - split filter validation, header/section printing, and warn/fail bookkeeping into dedicated helpers
+  - add one explicit unknown-workflow assertion so the refactor is not protected only by broad doctor coverage
+  - keep the sprint local to `bin/ai-doctor` and `test/ai_doctor.sh`
+- constraints:
+  - do not change doctor output ordering
+  - do not broaden the sprint into new diagnostics or docs
+  - keep helper extraction understandable for shell maintenance
+- current state: ai-doctor now reads more like staged reporting over helpers, and doctor tests protect unknown-workflow recovery more explicitly
+- next likely moves: either continue shell cleanup in one more bounded slice or shift fully into expansion work
+- open questions: whether global per-agent metadata in `ai-doctor` should eventually move toward more local return values
+
+## Lane Notes
+
+- Product / Backlog: turned the ai-doctor control-flow cleanup opportunity into Task 47 and issue `#113`
+- Delivery / Scrum: kept the sprint to one shell report surface plus one targeted doctor assertion
+- Implementer: updating `bin/ai-doctor` and `test/ai_doctor.sh`
+- Reviewer / QA: main risk is accidentally changing section ordering or next-step behavior while extracting helpers
+
+## Retrospective Output
+
+- keep
+  - bundling related cleanup work into one issue instead of many tiny PRs
+- change
+  - add a targeted recovery assertion whenever reporting control flow is rearranged
+- stop
+  - letting ai-doctor mix validation, printing, and state mutation inline once the contract has stabilized
+- follow-ups
+  - consider whether one more pass should reduce per-agent global metadata coupling
+
+## System Updates
+
+- backlog: updated
+- plans: updated
+- docs: not needed
+- tests: updated
+- instructions: not needed
+- ADR: not needed
+
+## Handoff
+
+- read first:
+  - `bin/ai-doctor`
+  - `test/ai_doctor.sh`
+- rerun commands:
+  - `bash test/ai_doctor.sh`
+  - `make lint`
+  - `make test`
+- known risks:
+  - helper extraction must not alter report ordering, next-step wording, or exit behavior

--- a/test/ai_doctor.sh
+++ b/test/ai_doctor.sh
@@ -218,6 +218,11 @@ filtered_output="$(
 [[ "$filtered_output" != *"workflow: unusable"* ]] || fail "filtered ai-doctor output included unrelated workflows"
 [[ "$filtered_output" != *"agent: claude_native"* ]] || fail "filtered ai-doctor output included unrelated agents"
 
+unknown_workflow_output="$(
+  cd "$TEST_REPO" && HOME="$TEST_HOME" PATH="$STUB_BIN:$ORIG_PATH" "$REPO/bin/ai-doctor" --workflow missing 2>&1 >/dev/null || true
+)"
+[[ "$unknown_workflow_output" == *"unknown workflow: missing"* ]] || fail "ai-doctor did not keep the unknown-workflow error"
+
 doctor_failure="$(
   cd "$TEST_REPO"
   set +e


### PR DESCRIPTION
## Summary
- refactor `ai-doctor` validation, section printing, and warning/failure bookkeeping into helpers
- keep current reporting and next-step behavior stable while reducing interleaved control flow
- add explicit unknown-workflow coverage and record the sprint closeout

## Testing
- bash test/ai_doctor.sh
- make lint
- make test

Closes #113
